### PR TITLE
le_print: dump Opcode value and name in the case of LL Control PDU.

### DIFF
--- a/lib/src/bluetooth_le_packet.c
+++ b/lib/src/bluetooth_le_packet.c
@@ -254,7 +254,7 @@ print128:
 }
 
 void le_print(le_packet_t *p) {
-	int i;
+	int i, opcode;
 	if (le_packet_is_data(p)) {
 		int llid = p->symbols[4] & 0x3;
 		static const char *llid_str[] = {
@@ -270,6 +270,31 @@ void le_print(le_packet_t *p) {
 		printf("    NESN: %d  SN: %d  MD: %d\n", (p->symbols[4] >> 2) & 1,
 												 (p->symbols[4] >> 3) & 1,
 												 (p->symbols[4] >> 4) & 1);
+		switch (llid) {
+		case 3: // LL Control PDU
+			opcode = p->symbols[6];
+			static const char *opcode_str[] = {
+				"LL_CONNECTION_UPDATE_REQ",
+				"LL_CHANNEL_MAP_REQ",
+				"LL_TERMINATE_IND",
+				"LL_ENC_REQ",
+				"LL_ENC_RSP",
+				"LL_START_ENC_REQ",
+				"LL_START_ENC_RSP",
+				"LL_UNKNOWN_RSP",
+				"LL_FEATURE_REQ",
+				"LL_FEATURE_RSP",
+				"LL_PAUSE_ENC_REQ",
+				"LL_PAUSE_ENC_RSP",
+				"LL_VERSION_IND",
+				"LL_REJECT_IND",
+				"Reserved for Future Use",
+			};
+			printf("    Opcode: %d / %s\n", opcode, opcode_str[(opcode<0x0E)?opcode:0x0E]);
+			break;
+		default:
+			break;
+		}
 	} else {
 		printf("Advertising / AA %08x / %2d bytes\n", p->access_address, p->length);
 		printf("    Channel Index: %d\n", p->channel_idx);


### PR DESCRIPTION
This CL adds one line to the textual packet dump (see Opcode: line below):

```
systime=1389684529 freq=2408 addr=9887b821 delta_t=69.836 ms
0f 08 01 0f f8 ff ff 1f 5d 00 0f 7d d3 
Data / AA 9887b821 /  8 bytes
    Channel Index: 2
    LLID: 3 / LL Control PDU
    NESN: 1  SN: 1  MD: 0
    Opcode: 1 / LL_CHANNEL_MAP_REQ

    Data:  01 0f f8 ff ff 1f 5d 00
    CRC:   0f 7d d3
```

I have taken the values from Bluetooth Spec 4.0 [Vol. 6], page 47 of 138.

Let me know if the patch needs to be refined or if it's too tiny to be accepted. I will be happy to fix or extend it.
