### PR TITLE
Add pcap and pcapng support to libbtbb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 cmake_minimum_required(VERSION 2.8)
 set(MAJOR_VERSION 0)
-set(MINOR_VERSION 2)
+set(MINOR_VERSION 3)
 project(libbtbb_all)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 

--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -22,9 +22,11 @@
 set(c_sources ${CMAKE_CURRENT_SOURCE_DIR}/bluetooth_packet.c
               ${CMAKE_CURRENT_SOURCE_DIR}/bluetooth_piconet.c
               ${CMAKE_CURRENT_SOURCE_DIR}/bluetooth_le_packet.c
+              ${CMAKE_CURRENT_SOURCE_DIR}/pcap.c
+              ${CMAKE_CURRENT_SOURCE_DIR}/pcapng.c
+              ${CMAKE_CURRENT_SOURCE_DIR}/pcapng-bt.c
 			  CACHE INTERNAL "List of C sources")
-set(c_headers ${CMAKE_CURRENT_SOURCE_DIR}/bluetooth_le_packet.h
-              ${CMAKE_CURRENT_SOURCE_DIR}/btbb.h
+set(c_headers ${CMAKE_CURRENT_SOURCE_DIR}/btbb.h
 			  CACHE INTERNAL "List of C headers")
 
 # For cygwin just force UNIX OFF and WIN32 ON

--- a/lib/src/bluetooth_le_packet.h
+++ b/lib/src/bluetooth_le_packet.h
@@ -37,7 +37,7 @@
 #define CONNECT_REQ		5
 #define ADV_SCAN_IND	6
 
-typedef struct _le_packet_t {
+struct lell_packet {
 	// raw unwhitened bytes of packet, including access address
 	uint8_t symbols[MAX_LE_SYMBOLS];
 
@@ -45,6 +45,7 @@ typedef struct _le_packet_t {
 
 	// channel index
 	uint8_t channel_idx;
+	uint8_t channel_k;
 
 	// number of symbols
 	int length;
@@ -55,21 +56,17 @@ typedef struct _le_packet_t {
 	uint8_t adv_type;
 	int adv_tx_add;
 	int adv_rx_add;
-} le_packet_t;
 
-/* decode payload */
-void decode_le(uint8_t *stream, uint16_t phys_channel, uint32_t clk100ns, le_packet_t *p);
+	unsigned access_address_offenses;
+	uint32_t refcount;
 
-/* returns true if this is a data packet, false if advertising */
-int le_packet_is_data(le_packet_t *p);
-
-/* returns the channel index of a physical channel */
-uint8_t le_channel_index(uint16_t phys_channel);
-
-/* returns a string representing advertising packet type */
-const char *le_adv_type(le_packet_t *p);
-
-/* print LE packet information */
-void le_print(le_packet_t *p);
+	/* flags */
+	union {
+		struct {
+			uint32_t access_address_ok : 1;
+		} as_bits;
+		uint32_t as_word;
+	} flags;
+};
 
 #endif /* INCLUDED_BLUETOOTH_LE_PACKET_H */

--- a/lib/src/bluetooth_packet.c
+++ b/lib/src/bluetooth_packet.c
@@ -194,7 +194,7 @@ static void gen_syndrome_map(int bit_errors)
 }
 
 /* Generate Sync Word from an LAP */
-uint64_t btbb_gen_syncword(int LAP)
+uint64_t btbb_gen_syncword(const int LAP)
 {
 	int i;
 	uint64_t codeword = DEFAULT_CODEWORD;
@@ -217,7 +217,7 @@ static void init_packet(btbb_packet *pkt, uint32_t lap, uint8_t ac_errors)
 }
 
 /* Convert some number of bits of an air order array to a host order integer */
-static uint8_t air_to_host8(char *air_order, int bits)
+static uint8_t air_to_host8(const char *air_order, const int bits)
 {
 	int i;
 	uint8_t host_order = 0;
@@ -225,7 +225,7 @@ static uint8_t air_to_host8(char *air_order, int bits)
 		host_order |= ((uint8_t)air_order[i] << i);
 	return host_order;
 }
-static uint16_t air_to_host16(char *air_order, int bits)
+static uint16_t air_to_host16(const char *air_order, const int bits)
 {
 	int i;
 	uint16_t host_order = 0;
@@ -233,7 +233,7 @@ static uint16_t air_to_host16(char *air_order, int bits)
 		host_order |= ((uint16_t)air_order[i] << i);
 	return host_order;
 }
-static uint32_t air_to_host32(char *air_order, int bits)
+static uint32_t air_to_host32(const char *air_order, const int bits)
 {
 	int i;
 	uint32_t host_order = 0;
@@ -241,7 +241,7 @@ static uint32_t air_to_host32(char *air_order, int bits)
 		host_order |= ((uint32_t)air_order[i] << i);
 	return host_order;
 }
-static uint64_t air_to_host64(char *air_order, int bits)
+static uint64_t air_to_host64(const char *air_order, const int bits)
 {
 	int i;
 	uint64_t host_order = 0;
@@ -251,7 +251,7 @@ static uint64_t air_to_host64(char *air_order, int bits)
 }
 
 /* Convert some number of bits in a host order integer to an air order array */
-static void host_to_air(uint8_t host_order, char *air_order, int bits)
+static void host_to_air(const uint8_t host_order, char *air_order, const int bits)
 {
     int i;
     for (i = 0; i < bits; i++)
@@ -303,7 +303,7 @@ btbb_packet_unref(btbb_packet *pkt)
 		free(pkt);
 }
 
-uint32_t btbb_packet_get_lap(btbb_packet *pkt)
+uint32_t btbb_packet_get_lap(const btbb_packet *pkt)
 {
 	return pkt->LAP;
 }
@@ -314,25 +314,25 @@ void btbb_packet_set_uap(btbb_packet *pkt, uint8_t uap)
 	btbb_packet_set_flag(pkt, BTBB_UAP_VALID, 1);
 }
 
-uint8_t btbb_packet_get_uap(btbb_packet *pkt)
+uint8_t btbb_packet_get_uap(const btbb_packet *pkt)
 {
 	return pkt->UAP;
 }
 
-uint16_t btbb_packet_get_nap(btbb_packet *pkt)
+uint16_t btbb_packet_get_nap(const btbb_packet *pkt)
 {
 	return pkt->NAP;
 }
 
-uint32_t btbb_packet_get_clkn(btbb_packet *pkt) {
+uint32_t btbb_packet_get_clkn(const btbb_packet *pkt) {
 	return pkt->clkn;
 }
 
-uint8_t btbb_packet_get_channel(btbb_packet *pkt) {
+uint8_t btbb_packet_get_channel(const btbb_packet *pkt) {
 	return pkt->channel;
 }
 
-uint8_t btbb_packet_get_ac_errors(btbb_packet *pkt) {
+uint8_t btbb_packet_get_ac_errors(const btbb_packet *pkt) {
 	return pkt->ac_errors;
 }
 
@@ -456,28 +456,28 @@ void btbb_packet_set_flag(btbb_packet *pkt, int flag, int val)
 		pkt->flags |= mask;
 }
 
-int btbb_packet_get_flag(btbb_packet *pkt, int flag)
+int btbb_packet_get_flag(const btbb_packet *pkt, int flag)
 {
 	uint32_t mask = 1L << flag;
 	return ((pkt->flags & mask) != 0);
 }
 
-const char *btbb_get_symbols(btbb_packet* pkt)
+const char *btbb_get_symbols(const btbb_packet* pkt)
 {
 	return (const char*) pkt->symbols;
 }
 
-int btbb_packet_get_payload_length(btbb_packet* pkt)
+int btbb_packet_get_payload_length(const btbb_packet* pkt)
 {
 	return pkt->payload_length;
 }
 
-const char *btbb_get_payload(btbb_packet* pkt)
+const char *btbb_get_payload(const btbb_packet* pkt)
 {
 	return (const char*) pkt->payload;
 }
 
-int btbb_get_payload_packed(btbb_packet* pkt, char *dst)
+int btbb_get_payload_packed(const btbb_packet* pkt, char *dst)
 {
 	int i;
 	for(i=0;i<pkt->payload_length;i++)
@@ -485,24 +485,29 @@ int btbb_get_payload_packed(btbb_packet* pkt, char *dst)
 	return pkt->payload_length;
 }
 
-uint8_t btbb_packet_get_type(btbb_packet* pkt)
+uint8_t btbb_packet_get_type(const btbb_packet* pkt)
 {
 	return pkt->packet_type;
 }
 
-uint8_t btbb_packet_get_lt_addr(btbb_packet* pkt)
+uint8_t btbb_packet_get_lt_addr(const btbb_packet* pkt)
 {
 	return pkt->packet_lt_addr;
 }
 
-uint8_t btbb_packet_get_header_flags(btbb_packet* pkt)
+uint8_t btbb_packet_get_header_flags(const btbb_packet* pkt)
 {
 	return pkt->packet_flags;
 }
 
-uint8_t btbb_packet_get_hec(btbb_packet* pkt)
+uint8_t btbb_packet_get_hec(const btbb_packet* pkt)
 {
 	return pkt->packet_hec;
+}
+
+uint32_t btbb_packet_get_header_packed(const btbb_packet* pkt)
+{
+	return air_to_host32(&pkt->packet_header[0], 18);
 }
 
 /* Compare stream with sync word
@@ -1242,7 +1247,7 @@ int btbb_decode_payload(btbb_packet* pkt)
 }
 
 /* print packet information */
-void btbb_print_packet(btbb_packet* pkt)
+void btbb_print_packet(const btbb_packet* pkt)
 {
 	if (btbb_packet_get_flag(pkt, BTBB_HAS_PAYLOAD)) {
 		printf("  Type: %s\n", TYPE_NAMES[pkt->packet_type]);
@@ -1293,10 +1298,10 @@ char *tun_format(btbb_packet* pkt)
 }
 
 /* check to see if the packet has a header */
-int btbb_header_present(btbb_packet* pkt)
+int btbb_header_present(const btbb_packet* pkt)
 {
 	/* skip to last bit of sync word */
-	char *stream = pkt->symbols + 63;
+	const char *stream = pkt->symbols + 63;
 	int be = 0; /* bit errors */
 	char msb;   /* most significant (last) bit of sync word */
 	int a, b, c;

--- a/lib/src/bluetooth_piconet.c
+++ b/lib/src/bluetooth_piconet.c
@@ -65,7 +65,7 @@ void btbb_piconet_set_flag(btbb_piconet *pn, int flag, int val)
 		pn->flags |= mask;
 }
 
-int btbb_piconet_get_flag(btbb_piconet *pn, int flag)
+int btbb_piconet_get_flag(const btbb_piconet *pn, const int flag)
 {
 	uint32_t mask = 1L << flag;
 	return ((pn->flags & mask) != 0);
@@ -77,22 +77,22 @@ void btbb_piconet_set_uap(btbb_piconet *pn, uint8_t uap)
 	btbb_piconet_set_flag(pn, BTBB_UAP_VALID, 1);
 }
 
-uint8_t btbb_piconet_get_uap(btbb_piconet *pn)
+uint8_t btbb_piconet_get_uap(const btbb_piconet *pn)
 {
 	return pn->UAP;
 }
 
-uint32_t btbb_piconet_get_lap(btbb_piconet *pn)
+uint32_t btbb_piconet_get_lap(const btbb_piconet *pn)
 {
 	return pn->LAP;
 }
 
-uint16_t btbb_piconet_get_nap(btbb_piconet *pn)
+uint16_t btbb_piconet_get_nap(const btbb_piconet *pn)
 {
 	return pn->NAP;
 }
 
-int btbb_piconet_get_clk_offset(btbb_piconet *pn)
+int btbb_piconet_get_clk_offset(const btbb_piconet *pn)
 {
 	return pn->clk_offset;
 }

--- a/lib/src/btbb.h
+++ b/lib/src/btbb.h
@@ -46,6 +46,8 @@ extern "C"
 {
 #endif
 
+/* BT BR/EDR support */
+
 typedef struct btbb_packet btbb_packet;
 
 /* Initialize the library. Compute the syndrome. Return 0 on success,
@@ -76,18 +78,20 @@ int btbb_find_ac(char *stream,
 	       int max_ac_errors,
 	       btbb_packet **pkt);
 #define LAP_ANY 0xffffffffUL
+#define UAP_ANY 0xff
 
 void btbb_packet_set_flag(btbb_packet *pkt, int flag, int val);
-int btbb_packet_get_flag(btbb_packet *pkt, int flag);
+int btbb_packet_get_flag(const btbb_packet *pkt, int flag);
 
-uint32_t btbb_packet_get_lap(btbb_packet *pkt);
+uint32_t btbb_packet_get_lap(const btbb_packet *pkt);
 void btbb_packet_set_uap(btbb_packet *pkt, uint8_t uap);
-uint8_t btbb_packet_get_uap(btbb_packet *pkt);
-uint16_t btbb_packet_get_nap(btbb_packet *pkt);
+uint8_t btbb_packet_get_uap(const btbb_packet *pkt);
+uint16_t btbb_packet_get_nap(const btbb_packet *pkt);
 
-uint8_t btbb_packet_get_channel(btbb_packet *pkt);
-uint8_t btbb_packet_get_ac_errors(btbb_packet *pkt);
-uint32_t btbb_packet_get_clkn(btbb_packet *pkt);
+uint8_t btbb_packet_get_channel(const btbb_packet *pkt);
+uint8_t btbb_packet_get_ac_errors(const btbb_packet *pkt);
+uint32_t btbb_packet_get_clkn(const btbb_packet *pkt);
+uint32_t btbb_packet_get_header_packed(const btbb_packet* pkt);
 
 void btbb_packet_set_data(btbb_packet *pkt,
 			  char *syms,      // Symbol data
@@ -96,23 +100,23 @@ void btbb_packet_set_data(btbb_packet *pkt,
 			  uint32_t clkn);  // 312.5us clock (CLK27-0)
 
 /* Get a pointer to packet symbols. */
-const char *btbb_get_symbols(btbb_packet* pkt);
+const char *btbb_get_symbols(const btbb_packet* pkt);
 
-int btbb_packet_get_payload_length(btbb_packet* pkt);
+int btbb_packet_get_payload_length(const btbb_packet* pkt);
 
 /* Get a pointer to payload. */
-const char *btbb_get_payload(btbb_packet* pkt);
+const char *btbb_get_payload(const btbb_packet* pkt);
 
 /* Pack the payload in to bytes */
-int btbb_get_payload_packed(btbb_packet* pkt, char *dst);
+int btbb_get_payload_packed(const btbb_packet* pkt, char *dst);
 
-uint8_t btbb_packet_get_type(btbb_packet* pkt);
-uint8_t btbb_packet_get_lt_addr(btbb_packet* pkt);
-uint8_t btbb_packet_get_header_flags(btbb_packet* pkt);
-uint8_t btbb_packet_get_hec(btbb_packet *pkt);
+uint8_t btbb_packet_get_type(const btbb_packet* pkt);
+uint8_t btbb_packet_get_lt_addr(const btbb_packet* pkt);
+uint8_t btbb_packet_get_header_flags(const btbb_packet* pkt);
+uint8_t btbb_packet_get_hec(const btbb_packet *pkt);
 
 /* Generate Sync Word from an LAP */
-uint64_t btbb_gen_syncword(int LAP);
+uint64_t btbb_gen_syncword(const int LAP);
 
 /* decode the packet header */
 int btbb_decode_header(btbb_packet* pkt);
@@ -121,10 +125,10 @@ int btbb_decode_header(btbb_packet* pkt);
 int btbb_decode_payload(btbb_packet* pkt);
 
 /* print packet information */
-void btbb_print_packet(btbb_packet* pkt);
+void btbb_print_packet(const btbb_packet* pkt);
 
 /* check to see if the packet has a header */
-int btbb_header_present(btbb_packet* pkt);
+int btbb_header_present(const btbb_packet* pkt);
 
 /* Packet queue (linked list) */
 typedef struct pkt_queue {
@@ -144,15 +148,15 @@ void btbb_piconet_unref(btbb_piconet *pn);
 void btbb_init_piconet(btbb_piconet *pn, uint32_t lap);
 
 void btbb_piconet_set_uap(btbb_piconet *pn, uint8_t uap);
-uint8_t btbb_piconet_get_uap(btbb_piconet *pn);
-uint32_t btbb_piconet_get_lap(btbb_piconet *pn);
-uint16_t btbb_piconet_get_nap(btbb_piconet *pn);
+uint8_t btbb_piconet_get_uap(const btbb_piconet *pn);
+uint32_t btbb_piconet_get_lap(const btbb_piconet *pn);
+uint16_t btbb_piconet_get_nap(const btbb_piconet *pn);
 
-int btbb_piconet_get_clk_offset(btbb_piconet *pn);
+int btbb_piconet_get_clk_offset(const btbb_piconet *pn);
 void btbb_piconet_set_clk_offset(btbb_piconet *pn, int clk_offset);
 
 void btbb_piconet_set_flag(btbb_piconet *pn, int flag, int val);
-int btbb_piconet_get_flag(btbb_piconet *pn, int flag);
+int btbb_piconet_get_flag(const btbb_piconet *pn, int flag);
 
 void btbb_piconet_set_channel_seen(btbb_piconet *pn, uint8_t channel);
 void btbb_piconet_set_afh_map(btbb_piconet *pn, uint8_t *afh_map);
@@ -181,6 +185,79 @@ int btbb_winnow(btbb_piconet *pn);
 int btbb_init_survey(void);
 /* Destructively iterate over survey results - optionally remove elements */
 btbb_piconet *btbb_next_survey_result(void);
+
+typedef struct btbb_pcapng_handle btbb_pcapng_handle;
+/* create a PCAPNG file for BREDR captures */
+int btbb_pcapng_create_file(const char *filename, const char *interface_desc, btbb_pcapng_handle ** ph);
+/* save a BREDR packet to PCAPNG capture file */
+int btbb_pcapng_append_packet(btbb_pcapng_handle * h, const uint64_t ns,
+                              const int8_t sigdbm, const int8_t noisedbm,
+                              const uint32_t reflap, const uint8_t refuap, 
+                              const btbb_packet *pkt);
+/* record a BDADDR to PCAPNG capture file */
+int btbb_pcapng_record_bdaddr(btbb_pcapng_handle * h, const uint64_t bdaddr,
+                              const uint8_t uapmask, const uint8_t napvalid);
+/* record BT CLOCK to PCAPNG capture file */
+int btbb_pcapng_record_btclock(btbb_pcapng_handle * h, const uint64_t bdaddr,
+                               const uint64_t ns, const uint32_t clk, const uint32_t clkmask);
+int btbb_pcapng_close(btbb_pcapng_handle * h);
+
+#if defined(USE_PCAP)
+typedef struct btbb_pcap_handle btbb_pcap_handle;
+/* create a PCAP file for BREDR captures with LINKTYPE_BLUETOOTH_BREDR_BB */
+int btbb_pcap_create_file(const char *filename, btbb_pcap_handle ** ph);
+/* write a BREDR packet to PCAP file */
+int btbb_pcap_append_packet(btbb_pcap_handle * h, const uint64_t ns, 
+                            const int8_t sigdbm, const int8_t noisedbm,
+                            const uint32_t reflap, const uint8_t refuap, 
+                            const btbb_packet *pkt);
+int btbb_pcap_close(btbb_pcap_handle * h);
+#endif
+
+/* BTLE support */
+
+typedef struct lell_packet lell_packet;
+/* decode and allocate LE packet */
+void lell_allocate_and_decode(const uint8_t *stream, uint16_t phys_channel, uint32_t clk100ns, lell_packet **pkt);
+lell_packet *lell_packet_new(void);
+void lell_packet_ref(lell_packet *pkt);
+void lell_packet_unref(lell_packet *pkt);
+uint32_t lell_get_access_address(const lell_packet *pkt);
+unsigned lell_get_access_address_offenses(const lell_packet *pkt);
+unsigned lell_packet_is_data(const lell_packet *pkt);
+unsigned lell_get_channel_index(const lell_packet *pkt);
+unsigned lell_get_channel_k(const lell_packet *pkt);
+const char * lell_get_adv_type_str(const lell_packet *pkt);
+void lell_print(const lell_packet *pkt);
+
+typedef struct lell_pcapng_handle lell_pcapng_handle;
+/* create a PCAPNG file for LE captures */
+int lell_pcapng_create_file(const char *filename, const char *interface_desc, lell_pcapng_handle ** ph);
+/* save an LE packet to PCAPNG capture file */
+int lell_pcapng_append_packet(lell_pcapng_handle * h, const uint64_t ns,
+                              const int8_t sigdbm, const int8_t noisedbm,
+                              const uint32_t refAA, const lell_packet *pkt);
+/* record LE CONNECT_REQ parameters to PCAPNG capture file */
+int lell_pcapng_record_connect_req(lell_pcapng_handle * h, const uint64_t ns, const uint8_t * pdu);
+int lell_pcapng_close(lell_pcapng_handle *h);
+
+#if defined(USE_PCAP)
+typedef struct lell_pcap_handle lell_pcap_handle;
+/* create a PCAP file for LE captures using LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR */
+int lell_pcap_create_file(const char *filename, lell_pcap_handle ** ph);
+/* create a PCAP file for LE captures using LINKTYPE_PPI */
+int lell_pcap_ppi_create_file(const char *filename, int btle_ppi_version, lell_pcap_handle ** ph);
+/* save an LE packet to PCAP capture file */
+int lell_pcap_append_packet(lell_pcap_handle * h, const uint64_t ns,
+                            const int8_t sigdbm, const int8_t noisedbm,
+                            const uint32_t refAA, const lell_packet *pkt);
+int lell_pcap_append_ppi_packet(lell_pcap_handle * h, const uint64_t ns,
+                                const uint8_t clkn_high,
+                                const int8_t rssi_min, const int8_t rssi_max,
+                                const int8_t rssi_avg, const uint8_t rssi_count,
+                                const lell_packet *pkt);
+int lell_pcap_close(lell_pcap_handle *h);
+#endif
 
 #ifdef __cplusplus
 } // __cplusplus defined.

--- a/lib/src/pcap-common.h
+++ b/lib/src/pcap-common.h
@@ -1,0 +1,132 @@
+/* -*- c -*- */
+/*
+ * Copyright 2014 Christopher D. Kilgour techie AT whiterocker.com
+ *
+ * This file is part of libbtbb
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with libbtbb; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef PCAP_COMMON_DOT_H
+#define PCAP_COMMON_DOT_H
+
+/* pull definitions for BT DLTs and pseudoheaders from libpcap, if possible */
+#if defined(USE_PCAP)
+#include <pcap/pcap.h>
+#include <pcap/bluetooth.h>
+#endif
+
+#if defined( __APPLE__ )
+#include <CoreServices/CoreServices.h>
+#define htobe32 EndianU32_NtoB
+#define be32toh EndianU32_BtoN
+#define le32toh EndianU32_LtoN
+#define htobe64 EndianU64_NtoB
+#define be64toh EndianU64_BtoN
+#define htole16 EndianU16_NtoL
+#define htole32 EndianU32_NtoL
+#else
+#include <endian.h>
+#endif
+
+#if !defined( htole16 ) /* will be defined under Linux when endian.h already included */
+#if defined( __GNUC__ )
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+inline uint16_t htole16(uint16_t host_16bits) { return host_16bits; }
+inline uint16_t le16toh(uint16_t little_endian_16bits) { return little_endian_16bits; }
+inline uint32_t htole32(uint32_t host_32bits) { return host_32bits; }
+inline uint32_t le32toh(uint32_t little_endian_32bits) { return little_endian_32bits; }
+inline uint64_t htole64(uint64_t host_64bits) { return host_64bits; }
+inline uint64_t le64toh(uint64_t little_endian_64bits) { return little_endian_64bits; }
+#else
+#error "FIXME: need to support big-endian under GNU"
+#endif /* __BYTE_ORDER__ */
+#else /* not GNU C */
+#error "FIXME: need to support non-GNU compiler"
+#endif /* __GNUC__ */
+#endif /* htole16 */
+
+/* --------------------------------- BR/EDR ----------------------------- */
+
+#if !defined( DLT_BLUETOOTH_BREDR_BB )
+#define DLT_BLUETOOTH_BREDR_BB 255
+typedef struct __attribute__((packed)) _pcap_bluetooth_bredr_bb_header {
+        uint8_t rf_channel;
+        int8_t signal_power;
+        int8_t noise_power;
+        uint8_t access_code_offenses;
+        uint8_t payload_transport_rate;
+        uint8_t corrected_header_bits;
+        int16_t corrected_payload_bits;
+        uint32_t lap;
+        uint32_t ref_lap_uap;
+        uint32_t bt_header;
+        uint16_t flags;
+        uint8_t  br_edr_payload[0];
+} pcap_bluetooth_bredr_bb_header;
+#endif
+
+#define BREDR_GFSK              0x00
+#define BREDR_PI_OVER_2_DQPSK   0x01
+#define BREDR_8DPSK             0x02
+#define BREDR_TRANSPORT_ANY     0x00
+#define BREDR_TRANSPORT_SCO     0x01
+#define BREDR_TRANSPORT_ESCO    0x02
+#define BREDR_TRANSPORT_ACL     0x03
+#define BREDR_TRANSPORT_CSB     0x04
+
+#define BREDR_DEWHITENED        0x0001
+#define BREDR_SIGPOWER_VALID    0x0002
+#define BREDR_NOISEPOWER_VALID  0x0004
+#define BREDR_PAYLOAD_DECRYPTED 0x0008
+#define BREDR_REFLAP_VALID      0x0010
+#define BREDR_PAYLOAD_PRESENT   0x0020
+#define BREDR_CHANNEL_ALIASED   0x0040
+#define BREDR_REFUAP_VALID      0x0080
+#define BREDR_HEC_CHECKED       0x0100
+#define BREDR_HEC_VALID         0x0200
+#define BREDR_CRC_CHECKED       0x0400
+#define BREDR_CRC_VALID         0x0800
+#define BREDR_MIC_CHECKED       0x1000
+#define BREDR_MIC_VALID         0x2000
+
+/* --------------------------------- Low Energy ---------------------------- */
+
+#if !defined( DLT_BLUETOOTH_LE_LL_WITH_PHDR )
+#define DLT_BLUETOOTH_LE_LL_WITH_PHDR 256
+typedef struct __attribute__((packed)) _pcap_bluetooth_le_ll_header {
+        uint8_t rf_channel;
+        int8_t signal_power;
+        int8_t noise_power;
+        uint8_t access_address_offenses;
+        uint32_t ref_access_address;
+        uint16_t flags;
+        uint8_t le_packet[0];
+} pcap_bluetooth_le_ll_header;
+#endif
+
+#define LE_DEWHITENED        0x0001
+#define LE_SIGPOWER_VALID    0x0002
+#define LE_NOISEPOWER_VALID  0x0004
+#define LE_PACKET_DECRYPTED  0x0008
+#define LE_REF_AA_VALID      0x0010
+#define LE_AA_OFFENSES_VALID 0x0020
+#define LE_CHANNEL_ALIASED   0x0040
+#define LE_CRC_CHECKED       0x0400
+#define LE_CRC_VALID         0x0800
+#define LE_MIC_CHECKED       0x1000
+#define LE_MIC_VALID         0x2000
+
+#endif /* PCAP_COMMON_DOT_H */

--- a/lib/src/pcap.c
+++ b/lib/src/pcap.c
@@ -1,0 +1,409 @@
+/* -*- c -*- */
+/*
+ * Copyright 2014 Christopher D. Kilgour techie AT whiterocker.com
+ *
+ * This file is part of libbtbb
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with libbtbb; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#include "bluetooth_le_packet.h"
+#include "btbb.h"
+#include "pcap-common.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef enum {
+	PCAP_OK = 0,
+	PCAP_INVALID_HANDLE,
+	PCAP_FILE_NOT_ALLOWED,
+	PCAP_NO_MEMORY,
+} PCAP_RESULT;
+
+#if defined(USE_PCAP)
+
+/* BT BR/EDR support */
+
+typedef struct btbb_pcap_handle {
+	pcap_t *        pcap;
+	pcap_dumper_t * dumper;
+} btbb_pcap_handle;
+
+int 
+btbb_pcap_create_file(const char *filename, btbb_pcap_handle ** ph)
+{
+	int retval = 0;
+	btbb_pcap_handle * handle = malloc( sizeof(btbb_pcap_handle) );
+	if (handle) {
+		memset(handle, 0, sizeof(*handle));
+		handle->pcap = pcap_open_dead_with_tstamp_precision(DLT_BLUETOOTH_BREDR_BB,
+								    400,
+								    PCAP_TSTAMP_PRECISION_NANO);
+		if (handle->pcap) {
+			handle->dumper = pcap_dump_open(handle->pcap, filename);
+			if (handle->dumper) {
+				*ph = handle;
+			}
+			else {
+				retval = -PCAP_FILE_NOT_ALLOWED;
+				goto fail;
+			}
+		}
+		else {
+			retval = -PCAP_INVALID_HANDLE;
+			goto fail;
+		}
+	}
+	else {
+		retval = -PCAP_NO_MEMORY;
+		goto fail;
+	}
+	return retval;
+fail:
+	(void) btbb_pcap_close( handle );
+	return retval;
+}
+
+typedef struct {
+	struct pcap_pkthdr pcap_header;
+	pcap_bluetooth_bredr_bb_header bredr_bb_header;
+	uint8_t bredr_payload[400];
+} pcap_bredr_packet;
+
+static void
+assemble_pcapng_bredr_packet( pcap_bredr_packet * pkt,
+			      const uint32_t interface_id,
+			      const uint64_t ns,
+			      const uint32_t caplen,
+			      const uint8_t rf_channel,
+			      const int8_t signal_power,
+			      const int8_t noise_power,
+			      const uint8_t access_code_offenses,
+			      const uint8_t payload_transport,
+			      const uint8_t payload_rate,
+			      const uint8_t corrected_header_bits,
+			      const int16_t corrected_payload_bits,
+			      const uint32_t lap,
+			      const uint32_t ref_lap,
+			      const uint8_t ref_uap,
+			      const uint32_t bt_header,
+			      const uint16_t flags,
+			      const uint8_t * payload )
+{
+	uint32_t pcap_caplen = sizeof(pcap_bluetooth_bredr_bb_header)+caplen;
+	uint32_t reflapuap = (ref_lap&0xffffff) | (ref_uap<<24);
+
+	pkt->pcap_header.ts.tv_sec  = ns / 1000000000ull;
+	pkt->pcap_header.ts.tv_usec = ns % 1000000000ull;
+	pkt->pcap_header.caplen = pcap_caplen;
+	pkt->pcap_header.len = pcap_caplen;
+
+	pkt->bredr_bb_header.rf_channel = rf_channel;
+	pkt->bredr_bb_header.signal_power = signal_power;
+	pkt->bredr_bb_header.noise_power = noise_power;
+	pkt->bredr_bb_header.access_code_offenses = access_code_offenses;
+	pkt->bredr_bb_header.payload_transport_rate =
+		(payload_transport << 4) | payload_rate;
+	pkt->bredr_bb_header.corrected_header_bits = corrected_header_bits;
+	pkt->bredr_bb_header.corrected_payload_bits = htole16( corrected_payload_bits );
+	pkt->bredr_bb_header.lap = htole32( lap );
+	pkt->bredr_bb_header.ref_lap_uap = htole32( reflapuap );
+	pkt->bredr_bb_header.bt_header = htole16( bt_header );
+	pkt->bredr_bb_header.flags = htole16( flags );
+	if (caplen) {
+		(void) memcpy( &pkt->bredr_payload[0], payload, caplen );
+	}
+	else {
+		pkt->bredr_bb_header.flags &= htole16( ~BREDR_PAYLOAD_PRESENT );
+	}
+}
+
+int 
+btbb_pcap_append_packet(btbb_pcap_handle * h, const uint64_t ns, 
+			const int8_t sigdbm, const int8_t noisedbm,
+			const uint32_t reflap, const uint8_t refuap, 
+			const btbb_packet *pkt)
+{
+	if (h && h->dumper) {
+		uint16_t flags = BREDR_DEWHITENED | BREDR_SIGPOWER_VALID |
+			((noisedbm < sigdbm) ? BREDR_NOISEPOWER_VALID : 0) |
+			((reflap != LAP_ANY) ? BREDR_REFLAP_VALID : 0) |
+			((refuap != UAP_ANY) ? BREDR_REFUAP_VALID : 0);
+		uint8_t payload_bytes[400];
+		uint32_t caplen = (uint32_t) btbb_get_payload_packed( pkt, (char *) &payload_bytes[0] );
+		pcap_bredr_packet pcap_pkt;
+		assemble_pcapng_bredr_packet( &pcap_pkt,
+					      0,
+					      ns,
+					      caplen,
+					      btbb_packet_get_channel(pkt),
+					      sigdbm,
+					      noisedbm,
+					      btbb_packet_get_ac_errors(pkt),
+					      BREDR_TRANSPORT_ANY,
+					      BREDR_GFSK, /* currently only supported */
+					      0, /* TODO: corrected header bits */
+					      0, /* TODO: corrected payload bits */
+					      btbb_packet_get_lap(pkt),
+					      reflap,
+					      refuap,
+					      btbb_packet_get_header_packed(pkt),
+					      flags,
+					      payload_bytes );
+		pcap_dump((u_char *)h->dumper, &pcap_pkt.pcap_header, (u_char *)&pcap_pkt.bredr_bb_header);
+		return 0;
+	}
+	return -PCAP_INVALID_HANDLE;
+}
+
+int 
+btbb_pcap_close(btbb_pcap_handle * h)
+{
+	if (h && h->dumper) {
+		pcap_dump_close(h->dumper);
+	}
+	if (h && h->pcap) {
+		pcap_close(h->pcap);
+	}
+	if (h) {
+		free(h);
+		return 0;
+	}
+	return -PCAP_INVALID_HANDLE;
+}
+
+/* BTLE support */
+
+typedef struct lell_pcap_handle {
+	pcap_t * pcap;
+	pcap_dumper_t * dumper;
+	int dlt;
+	uint8_t btle_ppi_version;
+} lell_pcap_handle;
+
+static int
+lell_pcap_create_file_dlt(const char *filename, int dlt, lell_pcap_handle ** ph)
+{
+	int retval = 0;
+	lell_pcap_handle * handle = malloc( sizeof(lell_pcap_handle) );
+	if (handle) {
+		memset(handle, 0, sizeof(*handle));
+		handle->pcap = pcap_open_dead_with_tstamp_precision(dlt,
+								    400,
+								    PCAP_TSTAMP_PRECISION_NANO);
+		if (handle->pcap) {
+			handle->dumper = pcap_dump_open(handle->pcap, filename);
+			if (handle->dumper) {
+				handle->dlt = dlt;
+				*ph = handle;
+			}
+			else {
+				retval = -PCAP_FILE_NOT_ALLOWED;
+				goto fail;
+			}
+		}
+		else {
+			retval = -PCAP_INVALID_HANDLE; 
+			goto fail;
+		}
+	}
+	else {
+		retval = -PCAP_NO_MEMORY;
+		goto fail;
+	}
+	return retval;
+fail:
+	(void) lell_pcap_close( handle );
+	return retval;
+}
+
+int 
+lell_pcap_create_file(const char *filename, lell_pcap_handle ** ph)
+{
+	return lell_pcap_create_file_dlt(filename, DLT_BLUETOOTH_LE_LL_WITH_PHDR, ph);
+}
+
+int 
+lell_pcap_ppi_create_file(const char *filename, int btle_ppi_version, 
+			  lell_pcap_handle ** ph)
+{
+	int retval = lell_pcap_create_file_dlt(filename, DLT_PPI, ph);
+	if (!retval) {
+		(*ph)->btle_ppi_version = btle_ppi_version;
+	}
+	return retval;
+}
+
+typedef struct {
+	struct pcap_pkthdr pcap_header;
+	pcap_bluetooth_le_ll_header le_ll_header;
+	uint8_t le_packet[48];
+} pcap_le_packet;
+
+static void
+assemble_pcapng_le_packet( pcap_le_packet * pkt,
+			   const uint32_t interface_id,
+			   const uint64_t ns,
+			   const uint32_t caplen,
+			   const uint8_t rf_channel,
+			   const int8_t signal_power,
+			   const int8_t noise_power,
+			   const uint8_t access_address_offenses,
+			   const uint32_t ref_access_address,
+			   const uint16_t flags,
+			   const uint8_t * lepkt )
+{
+	uint32_t pcap_caplen = sizeof(pcap_bluetooth_le_ll_header)+caplen;
+
+	pkt->pcap_header.ts.tv_sec  = ns / 1000000000ull;
+	pkt->pcap_header.ts.tv_usec = ns % 1000000000ull;
+	pkt->pcap_header.caplen = pcap_caplen;
+	pkt->pcap_header.len = pcap_caplen;
+
+	pkt->le_ll_header.rf_channel = rf_channel;
+	pkt->le_ll_header.signal_power = signal_power;
+	pkt->le_ll_header.noise_power = noise_power;
+	pkt->le_ll_header.access_address_offenses = access_address_offenses;
+	pkt->le_ll_header.ref_access_address = htole32( ref_access_address );
+	pkt->le_ll_header.flags = htole16( flags );
+	(void) memcpy( &pkt->le_packet[0], lepkt, caplen );
+}
+
+int 
+lell_pcap_append_packet(lell_pcap_handle * h, const uint64_t ns,
+			const int8_t sigdbm, const int8_t noisedbm,
+			const uint32_t refAA, const lell_packet *pkt)
+{
+	if (h && h->dumper &&
+	    (h->dlt == DLT_BLUETOOTH_LE_LL_WITH_PHDR)) {
+		uint16_t flags = LE_DEWHITENED | LE_AA_OFFENSES_VALID |
+			LE_SIGPOWER_VALID |
+			((noisedbm < sigdbm) ? LE_NOISEPOWER_VALID : 0) |
+			(lell_packet_is_data(pkt) ? 0 : LE_REF_AA_VALID);
+		pcap_le_packet pcap_pkt;
+		assemble_pcapng_le_packet( &pcap_pkt,
+					   0,
+					   ns,
+					   9+pkt->length,
+					   pkt->channel_k,
+					   sigdbm,
+					   noisedbm,
+					   pkt->access_address_offenses,
+					   refAA,
+					   flags,
+					   &pkt->symbols[0] );
+		pcap_dump((u_char *)h->dumper, &pcap_pkt.pcap_header, (u_char *)&pcap_pkt.le_ll_header);
+		return 0;
+	}
+	return -PCAP_INVALID_HANDLE;
+}
+
+#define PPI_BTLE 30006
+
+typedef struct __attribute__((packed)) {
+	uint8_t pph_version;
+	uint8_t pph_flags;
+	uint16_t pph_len;
+	uint32_t pph_dlt;
+} ppi_packet_header_t;
+
+typedef struct __attribute__((packed)) {
+	uint16_t pfh_type;
+	uint16_t pfh_datalen;
+} ppi_fieldheader_t;
+
+typedef struct __attribute__((packed)) {
+	uint8_t btle_version;
+	uint16_t btle_channel;
+	uint8_t btle_clkn_high;
+	uint32_t btle_clk100ns;
+	int8_t rssi_max;
+	int8_t rssi_min;
+	int8_t rssi_avg;
+	uint8_t rssi_count;
+} ppi_btle_t;
+
+typedef struct __attribute__((packed)) {
+	struct pcap_pkthdr pcap_header;
+        ppi_packet_header_t ppi_packet_header;
+	ppi_fieldheader_t ppi_fieldheader;
+	ppi_btle_t le_ll_ppi_header;
+	uint8_t le_packet[48];
+} pcap_ppi_le_packet;
+
+int 
+lell_pcap_append_ppi_packet(lell_pcap_handle * h, const uint64_t ns,
+			    const uint8_t clkn_high,
+			    const int8_t rssi_min, const int8_t rssi_max,
+			    const int8_t rssi_avg, const uint8_t rssi_count,
+			    const lell_packet *pkt)
+{
+	const ppi_packet_header_sz = sizeof(ppi_packet_header_t);
+	const ppi_fieldheader_sz = sizeof(ppi_fieldheader_t);
+	const le_ll_ppi_header_sz = sizeof(ppi_btle_t);
+
+	if (h && h->dumper && 
+	    (h->dlt == DLT_PPI)) {
+		pcap_ppi_le_packet pcap_pkt;
+		uint32_t pcap_caplen = 
+			ppi_packet_header_sz+ppi_fieldheader_sz+le_ll_ppi_header_sz+pkt->length;
+		uint16_t MHz = 2402 + 2*lell_get_channel_k(pkt);
+
+		pcap_pkt.pcap_header.ts.tv_sec  = ns / 1000000000ull;
+		pcap_pkt.pcap_header.ts.tv_usec = ns % 1000000000ull;
+		pcap_pkt.pcap_header.caplen = pcap_caplen;
+		pcap_pkt.pcap_header.len = pcap_caplen;
+
+		pcap_pkt.ppi_packet_header.pph_version = 0;
+		pcap_pkt.ppi_packet_header.pph_flags = 0;
+		pcap_pkt.ppi_packet_header.pph_len = htole16(ppi_packet_header_sz+ppi_fieldheader_sz+le_ll_ppi_header_sz);
+		pcap_pkt.ppi_packet_header.pph_dlt = htole32(DLT_USER0);
+
+		pcap_pkt.ppi_fieldheader.pfh_type = htole16(PPI_BTLE);
+		pcap_pkt.ppi_fieldheader.pfh_datalen = htole16(le_ll_ppi_header_sz);
+	
+		pcap_pkt.le_ll_ppi_header.btle_version = h->btle_ppi_version;
+		pcap_pkt.le_ll_ppi_header.btle_channel = htole16(MHz);
+		pcap_pkt.le_ll_ppi_header.btle_clkn_high = clkn_high;
+		pcap_pkt.le_ll_ppi_header.btle_clk100ns = htole32(pkt->clk100ns);
+		pcap_pkt.le_ll_ppi_header.rssi_max = rssi_max;
+		pcap_pkt.le_ll_ppi_header.rssi_min = rssi_min;
+		pcap_pkt.le_ll_ppi_header.rssi_avg = rssi_avg;
+		pcap_pkt.le_ll_ppi_header.rssi_count = rssi_count;
+		(void) memcpy( &pcap_pkt.le_packet[0], &pkt->symbols[0], pcap_caplen );
+		pcap_dump((u_char *)h->dumper, &pcap_pkt.pcap_header, (u_char *)&pcap_pkt.le_ll_ppi_header);
+		return 0;
+	}
+	return -PCAP_INVALID_HANDLE;
+}
+
+int 
+lell_pcap_close(lell_pcap_handle *h)
+{
+	if (h && h->dumper) {
+		pcap_dump_close(h->dumper);
+	}
+	if (h && h->pcap) {
+		pcap_close(h->pcap);
+	}
+	if (h) {
+		free(h);
+		return 0;
+	}
+	return -PCAP_INVALID_HANDLE;
+}
+
+#endif /* USE_PCAP */

--- a/lib/src/pcapng-bt.c
+++ b/lib/src/pcapng-bt.c
@@ -1,0 +1,505 @@
+/* -*- c -*- */
+/*
+ * Copyright 2014 Christopher D. Kilgour techie AT whiterocker.com
+ *
+ * This file is part of libbtbb
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with libbtbb; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "btbb.h"
+#include "bluetooth_le_packet.h"
+#include "pcapng-bt.h"
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+/* generic section options indicating libbtbb */
+const struct {
+	struct {
+		option_header hdr;
+		char libname[8];
+	} libopt;
+	struct {
+		option_header hdr;
+	} termopt;
+} libbtbb_section_options = {
+	.libopt = {
+		.hdr = {
+			.option_code = SHB_USERAPPL,
+			.option_length = 7 },
+		.libname = "libbtbb"
+	},
+	.termopt = {
+		.hdr = {
+			.option_code = OPT_ENDOFOPT,
+			.option_length = 0
+		}
+	}
+};
+
+static PCAPNG_RESULT
+check_and_fix_tsresol( PCAPNG_HANDLE * handle,
+		       const option_header * interface_options )
+{
+	PCAPNG_RESULT retval = PCAPNG_OK;
+	int got_tsresol = 0;
+
+	while( !got_tsresol &&
+	       interface_options &&
+	       interface_options->option_code &&
+	       interface_options->option_length) {
+		if (interface_options->option_code == IF_TSRESOL) {
+			got_tsresol = 1;
+		}
+		else {
+			size_t step = 4+4*((interface_options->option_length+3)/4);
+			uint8_t * next = &((uint8_t *)interface_options)[step];
+			interface_options = (const option_header *) next;
+		}
+	}
+
+	if (!got_tsresol) {
+		const struct {
+			option_header hdr;
+			uint8_t resol;
+		} tsresol = {
+			.hdr = {
+				.option_code = IF_TSRESOL,
+				.option_length = 1,
+			},
+			.resol = 9 /* 10^-9 is nanoseconds */
+		};
+
+		retval = pcapng_append_interface_option( handle, 
+							 (const option_header *) &tsresol );
+	}
+
+	return retval;
+}
+
+/* --------------------------------- BR/EDR ----------------------------- */
+
+static PCAPNG_RESULT
+create_bredr_capture_file_single_interface( PCAPNG_HANDLE * handle,
+					    const char * filename,
+					    const option_header * interface_options )
+{
+	PCAPNG_RESULT retval = PCAPNG_OK;
+
+	retval = pcapng_create( handle,
+				filename,
+				(const option_header *) &libbtbb_section_options, 
+				(size_t) getpagesize( ),
+				DLT_BLUETOOTH_BREDR_BB,
+				400,
+				interface_options,
+				(size_t) getpagesize( ) );
+
+	if (retval == PCAPNG_OK) {
+		/* if there is no timestamp resolution alread in the
+		   interface options, record nanosecond resolution */
+		retval = check_and_fix_tsresol( handle, interface_options );
+
+		if (retval != PCAPNG_OK) {
+			(void) pcapng_close( handle );
+		}
+	}
+
+	return retval;
+}
+
+int btbb_pcapng_create_file( const char *filename,
+			     const char *interface_desc,
+			     btbb_pcapng_handle ** ph )
+{
+	int retval = PCAPNG_OK;
+	PCAPNG_HANDLE * handle = malloc( sizeof(PCAPNG_HANDLE) );
+	if (handle) {
+		const option_header * popt = NULL;
+		struct {
+			option_header header;
+			char desc[256];
+		} ifopt = {
+			.header = {
+				.option_code = IF_DESCRIPTION,
+			}
+		};
+		if (interface_desc) {
+			(void) strncpy( &ifopt.desc[0], interface_desc, 256 );
+			ifopt.desc[255] = '\0';
+			ifopt.header.option_length = strlen( ifopt.desc );
+			popt = (const option_header *) &ifopt;
+		}
+
+		retval = -create_bredr_capture_file_single_interface( handle,
+								      filename,
+								      popt );
+		if (retval == PCAPNG_OK) {
+			*ph = (btbb_pcapng_handle *) handle;
+		}
+		else {
+			free( handle );
+		}
+	}
+	else {
+		retval = -PCAPNG_NO_MEMORY;
+	}
+	return retval;
+}
+
+static PCAPNG_RESULT
+append_bredr_packet( PCAPNG_HANDLE * handle,
+		     pcapng_bredr_packet * pkt )
+{
+	return pcapng_append_packet( handle, ( const enhanced_packet_block *) pkt );
+}
+
+static void
+assemble_pcapng_bredr_packet( pcapng_bredr_packet * pkt,
+			      const uint32_t interface_id,
+			      const uint64_t ns,
+			      const uint32_t caplen,
+			      const uint8_t rf_channel,
+			      const int8_t signal_power,
+			      const int8_t noise_power,
+			      const uint8_t access_code_offenses,
+			      const uint8_t payload_transport,
+			      const uint8_t payload_rate,
+			      const uint8_t corrected_header_bits,
+			      const int16_t corrected_payload_bits,
+			      const uint32_t lap,
+			      const uint32_t ref_lap,
+                              const uint8_t ref_uap,
+			      const uint32_t bt_header,
+			      const uint16_t flags,
+			      const uint8_t * payload )
+{
+	uint32_t pcapng_caplen = sizeof(pcap_bluetooth_bredr_bb_header)+caplen;
+	uint32_t block_length  = 4*((36+pcapng_caplen+3)/4);
+	uint32_t reflapuap = (ref_lap&0xffffff) | (ref_uap<<24);
+
+	pkt->blk_header.block_type = BLOCK_TYPE_ENHANCED_PACKET;
+	pkt->blk_header.block_total_length = block_length;
+	pkt->blk_header.interface_id = interface_id;
+	pkt->blk_header.timestamp_high = (uint32_t) (ns >> 32);
+	pkt->blk_header.timestamp_low = (uint32_t) (ns & 0x0ffffffffull);
+	pkt->blk_header.captured_len = pcapng_caplen;
+	pkt->blk_header.packet_len = pcapng_caplen;
+	pkt->bredr_bb_header.rf_channel = rf_channel;
+	pkt->bredr_bb_header.signal_power = signal_power;
+	pkt->bredr_bb_header.noise_power = noise_power;
+	pkt->bredr_bb_header.access_code_offenses = access_code_offenses;
+	pkt->bredr_bb_header.payload_transport_rate =
+		(payload_transport << 4) | payload_rate;
+	pkt->bredr_bb_header.corrected_header_bits = corrected_header_bits;
+	pkt->bredr_bb_header.corrected_payload_bits = htole16( corrected_payload_bits );
+	pkt->bredr_bb_header.lap = htole32( lap );
+	pkt->bredr_bb_header.ref_lap_uap = htole32( reflapuap );
+	pkt->bredr_bb_header.bt_header = htole16( bt_header );
+	pkt->bredr_bb_header.flags = htole16( flags );
+	if (caplen) {
+		(void) memcpy( &pkt->bredr_payload[0], payload, caplen );
+	}
+	else {
+		pkt->bredr_bb_header.flags &= htole16( ~BREDR_PAYLOAD_PRESENT );
+	}
+	((uint32_t *)pkt)[block_length/4-2] = 0x00000000; /* no-options */
+	((uint32_t *)pkt)[block_length/4-1] = block_length;
+}
+
+int btbb_pcapng_append_packet(btbb_pcapng_handle * h, const uint64_t ns,
+			      const int8_t sigdbm, const int8_t noisedbm,
+			      const uint32_t reflap, const uint8_t refuap, 
+			      const btbb_packet *pkt)
+{
+	uint16_t flags = BREDR_DEWHITENED | BREDR_SIGPOWER_VALID |
+		((noisedbm < sigdbm) ? BREDR_NOISEPOWER_VALID : 0) |
+		((reflap != LAP_ANY) ? BREDR_REFLAP_VALID : 0) |
+		((refuap != UAP_ANY) ? BREDR_REFUAP_VALID : 0);
+	uint8_t payload_bytes[400];
+	uint32_t caplen = (uint32_t) btbb_get_payload_packed( pkt, (char *) &payload_bytes[0] );
+	pcapng_bredr_packet pcapng_pkt;
+	assemble_pcapng_bredr_packet( &pcapng_pkt,
+				      0,
+				      ns,
+				      caplen,
+				      btbb_packet_get_channel(pkt),
+				      sigdbm,
+				      noisedbm,
+				      btbb_packet_get_ac_errors(pkt),
+				      BREDR_TRANSPORT_ANY,
+				      BREDR_GFSK, /* currently only supported */
+				      0, /* TODO: corrected header bits */
+				      0, /* TODO: corrected payload bits */
+				      btbb_packet_get_lap(pkt),
+				      reflap,
+				      refuap,
+				      btbb_packet_get_header_packed(pkt),
+				      flags,
+				      payload_bytes );
+	return -append_bredr_packet( (PCAPNG_HANDLE *)h, &pcapng_pkt );
+}
+
+static PCAPNG_RESULT
+record_bd_addr_info( PCAPNG_HANDLE * handle,
+		     const uint64_t bd_addr,
+		     const uint8_t  uap_mask,
+                     const uint8_t  nap_valid )
+{
+	const bredr_br_addr_option bdopt = {
+		.header = {
+			.option_code = PCAPNG_BREDR_OPTION_BD_ADDR,
+			.option_length = sizeof(bredr_br_addr_option),
+		},
+		.bd_addr_info = {
+			.bd_addr = {
+				((bd_addr>>0)  & 0xff),
+				((bd_addr>>8)  & 0xff),
+				((bd_addr>>16) & 0xff),
+				((bd_addr>>24) & 0xff),
+				((bd_addr>>32) & 0xff),
+				((bd_addr>>40) & 0xff)
+			},
+			.uap_mask = uap_mask,
+			.nap_valid = nap_valid,
+		}
+	};
+	return pcapng_append_interface_option( handle,
+					       (const option_header *) &bdopt );
+}
+
+int btbb_pcapng_record_bdaddr(btbb_pcapng_handle * h, const uint64_t bdaddr,
+                              const uint8_t uapmask, const uint8_t napvalid)
+{
+	return -record_bd_addr_info( (PCAPNG_HANDLE *) h,
+				     bdaddr, uapmask, napvalid );
+}
+
+static PCAPNG_RESULT
+record_bredr_master_clock_info( PCAPNG_HANDLE * handle,
+				const uint64_t bd_addr,
+				const uint64_t ns,
+				const uint32_t clk,
+	                        const uint32_t clk_mask)
+{
+	const bredr_clk_option mcopt = {
+		.header = {
+			.option_code = PCAPNG_BREDR_OPTION_MASTER_CLOCK_INFO,
+			.option_length = sizeof(bredr_clk_option)
+		},
+		.clock_info = {
+			.ts = ns,
+			.lap_uap = htole32(bd_addr & 0xffffffff),
+			.clk = clk,
+			.clk_mask = clk_mask
+		}
+	};
+	return pcapng_append_interface_option( handle,
+					       (const option_header *) &mcopt );
+}
+
+int btbb_pcapng_record_btclock(btbb_pcapng_handle * h, const uint64_t bdaddr,
+                               const uint64_t ns, const uint32_t clk,
+			       const uint32_t clkmask)
+{
+	return -record_bredr_master_clock_info( (PCAPNG_HANDLE *) h,
+						bdaddr, ns, clk, clkmask );
+}
+
+int btbb_pcapng_close(btbb_pcapng_handle * h)
+{
+	pcapng_close( (PCAPNG_HANDLE *) h );
+	if (h) {
+		free( h );
+	}
+	return -PCAPNG_INVALID_HANDLE;
+}
+
+/* --------------------------------- Low Energy ---------------------------- */
+
+static PCAPNG_RESULT
+create_le_capture_file_single_interface( PCAPNG_HANDLE * handle,
+					 const char * filename,
+					 const option_header * interface_options )
+{
+	PCAPNG_RESULT retval = PCAPNG_OK;
+
+	retval = pcapng_create( handle,
+				filename,
+				(const option_header *) &libbtbb_section_options, 
+				(size_t) getpagesize( ),
+				DLT_BLUETOOTH_LE_LL_WITH_PHDR,
+				64,
+				interface_options,
+				(size_t) getpagesize( ) );
+
+	if (retval == PCAPNG_OK) {
+		/* if there is no timestamp resolution alread in the
+		   interface options, record nanosecond resolution */
+		retval = check_and_fix_tsresol( handle, interface_options );
+
+		if (retval != PCAPNG_OK) {
+			(void) pcapng_close( handle );
+		}
+	}
+
+	return retval;
+}
+
+int
+lell_pcapng_create_file(const char *filename, const char *interface_desc,
+			lell_pcapng_handle ** ph)
+{
+	int retval = PCAPNG_OK;
+	PCAPNG_HANDLE * handle = malloc( sizeof(PCAPNG_HANDLE) );
+	if (handle) {
+		const option_header * popt = NULL;
+		struct {
+			option_header header;
+			char desc[256];
+		} ifopt = {
+			.header = {
+				.option_code = IF_DESCRIPTION,
+			}
+		};
+		if (interface_desc) {
+			(void) strncpy( &ifopt.desc[0], interface_desc, 256 );
+			ifopt.desc[255] = '\0';
+			ifopt.header.option_length = strlen( ifopt.desc );
+			popt = (const option_header *) &ifopt;
+		}
+
+		retval = -create_le_capture_file_single_interface( handle,
+								   filename,
+								   popt );
+		if (retval == PCAPNG_OK) {
+			*ph = (lell_pcapng_handle *) handle;
+		}
+		else {
+			free( handle );
+		}
+	}
+	else {
+		retval = -PCAPNG_NO_MEMORY;
+	}
+	return retval;
+}
+
+static PCAPNG_RESULT
+append_le_packet( PCAPNG_HANDLE * handle,
+		  pcapng_le_packet * pkt )
+{
+	return pcapng_append_packet( handle, ( const enhanced_packet_block *) pkt );
+}
+
+static void
+assemble_pcapng_le_packet( pcapng_le_packet * pkt,
+			   const uint32_t interface_id,
+			   const uint64_t ns,
+			   const uint32_t caplen,
+			   const uint8_t rf_channel,
+			   const int8_t signal_power,
+			   const int8_t noise_power,
+			   const uint8_t access_address_offenses,
+			   const uint32_t ref_access_address,
+			   const uint16_t flags,
+			   const uint8_t * lepkt )
+{
+	uint32_t pcapng_caplen = sizeof(pcap_bluetooth_le_ll_header)+caplen;
+	uint32_t block_length  = 4*((36+pcapng_caplen+3)/4);
+
+	pkt->blk_header.block_type = BLOCK_TYPE_ENHANCED_PACKET;
+	pkt->blk_header.block_total_length = block_length;
+	pkt->blk_header.interface_id = interface_id;
+	pkt->blk_header.timestamp_high = (uint32_t) (ns >> 32);
+	pkt->blk_header.timestamp_low = (uint32_t) (ns & 0x0ffffffffull);
+	pkt->blk_header.captured_len = pcapng_caplen;
+	pkt->blk_header.packet_len = pcapng_caplen;
+	pkt->le_ll_header.rf_channel = rf_channel;
+	pkt->le_ll_header.signal_power = signal_power;
+	pkt->le_ll_header.noise_power = noise_power;
+	pkt->le_ll_header.access_address_offenses = access_address_offenses;
+	pkt->le_ll_header.ref_access_address = htole32( ref_access_address );
+	pkt->le_ll_header.flags = htole16( flags );
+	(void) memcpy( &pkt->le_packet[0], lepkt, caplen );
+	((uint32_t *)pkt)[block_length/4-2] = 0x00000000; /* no-options */
+	((uint32_t *)pkt)[block_length/4-1] = block_length;
+}
+
+int
+lell_pcapng_append_packet(lell_pcapng_handle * h, const uint64_t ns,
+			  const int8_t sigdbm, const int8_t noisedbm,
+			  const uint32_t refAA, const lell_packet *pkt)
+{
+	uint16_t flags = LE_DEWHITENED | LE_AA_OFFENSES_VALID |
+		LE_SIGPOWER_VALID |
+		((noisedbm < sigdbm) ? LE_NOISEPOWER_VALID : 0) |
+		(lell_packet_is_data(pkt) ? 0 : LE_REF_AA_VALID);
+	pcapng_le_packet pcapng_pkt;
+	assemble_pcapng_le_packet( &pcapng_pkt,
+				   0,
+				   ns,
+				   9+pkt->length,
+				   pkt->channel_k,
+				   sigdbm,
+				   noisedbm,
+				   pkt->access_address_offenses,
+				   refAA,
+				   flags,
+				   &pkt->symbols[0] );
+	int retval = -append_le_packet( (PCAPNG_HANDLE *) h, &pcapng_pkt );
+	if ((retval == 0) && !lell_packet_is_data(pkt) && (pkt->adv_type == CONNECT_REQ)) {
+		(void) lell_pcapng_record_connect_req(h, ns, &pkt->symbols[0]);
+	}
+	return retval;
+}
+
+static PCAPNG_RESULT
+record_le_connect_req_info( PCAPNG_HANDLE * handle,
+			    const uint64_t ns,
+			    const uint8_t * pdu )
+{
+	le_ll_connection_info_option cropt = {
+		.header = {
+			.option_code = PCAPNG_LE_LL_CONNECTION_INFO,
+			.option_length = sizeof(le_ll_connection_info_option)
+		},
+		.connection_info = {
+			.ns = ns
+		}
+	};
+	(void) memcpy( &cropt.connection_info.pdu.bytes[0], pdu, 34 );
+	return pcapng_append_interface_option( handle,
+					       (const option_header *) &cropt );
+}
+
+int
+lell_pcapng_record_connect_req(lell_pcapng_handle * h, const uint64_t ns, 
+			       const uint8_t * pdu)
+{
+	return -record_le_connect_req_info( (PCAPNG_HANDLE *) h, ns, pdu );
+}
+
+int lell_pcapng_close(lell_pcapng_handle *h)
+{
+	pcapng_close( (PCAPNG_HANDLE *) h );
+	if (h) {
+		free( h );
+	}
+	return -PCAPNG_INVALID_HANDLE;
+}

--- a/lib/src/pcapng-bt.h
+++ b/lib/src/pcapng-bt.h
@@ -1,0 +1,111 @@
+/* -*- c -*- */
+/*
+ * Copyright 2014 Christopher D. Kilgour techie AT whiterocker.com
+ *
+ * This file is part of libbtbb
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with libbtbb; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef PCAPNG_BT_DOT_H
+#define PCAPNG_BT_DOT_H
+
+#include "pcap-common.h"
+#include "pcapng.h"
+
+typedef struct __attribute__((packed)) {
+	uint32_t centre_freq;
+	uint32_t analog_bandwidth;
+	int32_t  intermediate_freq;
+	uint32_t sampling_bandwidth;
+} bt_wideband_rf_info;
+
+typedef struct __attribute__((packed)) {
+  option_header header;
+  bt_wideband_rf_info wideband_rf_info;
+} bt_wideband_rf_option;
+
+#define PCAPNG_BT_WIDEBAND_RF_INFO 0xd300
+
+/* --------------------------------- BR/EDR ----------------------------- */
+
+typedef struct __attribute__((packed)) {
+  enhanced_packet_block blk_header;
+  pcap_bluetooth_bredr_bb_header bredr_bb_header;
+  uint8_t bredr_payload[400];
+} pcapng_bredr_packet;
+
+typedef struct __attribute__((packed)) {
+  uint8_t bd_addr[6];
+  uint8_t uap_mask;
+  uint8_t nap_valid;
+} bredr_bd_addr_info;
+
+typedef struct __attribute__((packed)) {
+  option_header header;
+  bredr_bd_addr_info bd_addr_info;
+} bredr_br_addr_option;
+
+typedef struct __attribute__((packed)) {
+  uint64_t ts;
+  uint32_t lap_uap;
+  uint32_t clk;
+  uint32_t clk_mask;
+} bredr_clk_info;
+
+typedef struct __attribute__((packed)) {
+  option_header header;
+  bredr_clk_info clock_info;
+} bredr_clk_option;
+
+#define PCAPNG_BREDR_OPTION_BD_ADDR           0xd340
+#define PCAPNG_BREDR_OPTION_MASTER_CLOCK_INFO 0xd341
+
+/* --------------------------------- Low Energy ---------------------------- */
+
+typedef struct __attribute__((packed)) {
+  enhanced_packet_block blk_header;
+  pcap_bluetooth_le_ll_header le_ll_header;
+  uint8_t le_packet[48];
+} pcapng_le_packet;
+
+typedef struct __attribute__((packed)) {
+  uint64_t ns;
+  union {
+    struct {
+      uint8_t InitA[6];
+      uint8_t AdvA[6];
+      uint8_t AA[4];
+      uint8_t CRCInit[3];
+      uint8_t WinSize;
+      uint8_t WinOffset[2];
+      uint8_t Interval[2];
+      uint8_t Latency[2];
+      uint8_t Timeout[2];
+      uint8_t ChM[5];
+      uint8_t HopSCA;
+    } fields;
+    uint8_t bytes[0];
+  } pdu;
+} le_ll_connection_info;
+
+typedef struct __attribute__((packed)) {
+  option_header header;
+  le_ll_connection_info connection_info;
+} le_ll_connection_info_option;
+
+#define PCAPNG_LE_LL_CONNECTION_INFO 0xd380
+
+#endif /* PCAPNG_BT_DOT_H */

--- a/lib/src/pcapng.c
+++ b/lib/src/pcapng.c
@@ -1,0 +1,322 @@
+/* -*- c -*- */
+/*
+ * Copyright 2014 Christopher D. Kilgour techie AT whiterocker.com
+ *
+ * This file is part of libbtbb
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with libbtbb; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "pcapng.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static option_header padopt = {
+	.option_code = 0xffff,
+};
+
+PCAPNG_RESULT pcapng_create( PCAPNG_HANDLE * handle,
+			     const char * filename,
+			     const option_header * section_options,
+			     const size_t section_options_space,
+			     const uint16_t link_type,
+			     const uint32_t snaplen,
+			     const option_header * interface_options,
+			     const size_t interface_options_space )
+{
+	PCAPNG_RESULT retval = PCAPNG_OK;
+	int PGSZ = getpagesize( );
+	size_t zeroes = 0, result = -1;
+
+	handle->section_header = NULL;
+	handle->interface_description = NULL;
+	handle->section_header_size = handle->next_section_option_offset =
+		handle->interface_description_size =
+		handle->next_interface_option_offset = 0;
+
+	handle->fd = open( filename, O_RDWR|O_CREAT|O_EXCL, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP );
+	if (handle->fd == -1) {
+		switch( errno ) {
+		case EEXIST:
+			retval = PCAPNG_FILE_EXISTS;
+			break;
+		case EMFILE:
+		case ENFILE:
+			retval = PCAPNG_TOO_MANY_FILES_OPEN;
+			break;
+		case ENOMEM:
+		case ENOSPC:
+			retval = PCAPNG_NO_MEMORY;
+			break;
+		default:
+			retval = PCAPNG_FILE_NOT_ALLOWED;
+		}
+	}
+
+	if (retval == PCAPNG_OK) {
+		/* section header */
+		const section_header_block shb = {
+			.block_type = BLOCK_TYPE_SECTION_HEADER,
+			.block_total_length = 28,
+			.byte_order_magic = SECTION_HEADER_BYTE_ORDER_MAGIC,
+			.major_version = 1,
+			.minor_version = 0,
+			.section_length = (uint64_t) -1,
+		};
+		handle->section_header_size = sizeof( shb );
+		result = write( handle->fd, &shb, sizeof( shb ) );
+		/* write initial section options */
+		while ((result != -1) &&
+		       section_options &&
+		       section_options->option_code &&
+		       section_options->option_length) {
+			size_t paddedsz = 4*((section_options->option_length+3)/4);
+			zeroes = paddedsz - section_options->option_length;
+			result = write( handle->fd, section_options, 4+section_options->option_length );
+			while ((zeroes > 0) && (result != -1)) {
+				result = write( handle->fd, "\0", 1 );
+				zeroes--;
+			}
+			section_options = (const option_header *) &((uint8_t *)section_options)[4+paddedsz];
+			handle->section_header_size += (4+paddedsz);
+		}
+		handle->next_section_option_offset = handle->section_header_size;
+	}
+
+	if (result == -1) {
+		retval = PCAPNG_FILE_WRITE_ERROR;
+	}
+	else {
+		/* determine the size of section header with desired space */
+		zeroes = (size_t) PGSZ*((handle->section_header_size + 4 +
+					 section_options_space + PGSZ - 1)/PGSZ) -
+			handle->section_header_size;
+		handle->section_header_size += zeroes;
+		while ((zeroes > 0) && (result != -1)) {
+			result = write( handle->fd, "\0", 1 );
+			zeroes--;
+		}
+
+		/* mmap the section header */
+		handle->section_header = mmap( NULL, handle->section_header_size, 
+					       PROT_READ|PROT_WRITE,
+					       MAP_SHARED,
+					       handle->fd, 0 );
+	}
+
+	if (retval == PCAPNG_OK) {
+		if (result == -1) {
+			retval = PCAPNG_FILE_WRITE_ERROR;
+		}
+		else if (handle->section_header == MAP_FAILED) {
+			retval = PCAPNG_MMAP_FAILED;
+		}
+		else {
+			/* write the interface header */
+			const interface_description_block idb = {
+				.block_type = BLOCK_TYPE_INTERFACE,
+				.block_total_length = 0,
+				.link_type = link_type,
+				.snaplen = snaplen
+			};
+			handle->interface_description_size = sizeof( idb );
+			result = write( handle->fd, &idb, sizeof( idb ) );
+
+			/* write interface options */
+			while ((result != -1) &&
+			       interface_options &&
+			       interface_options->option_code &&
+			       interface_options->option_length) {
+				size_t paddedsz = 4*((interface_options->option_length+3)/4);
+				zeroes = paddedsz - interface_options->option_length;
+				result = write( handle->fd, interface_options, 4+interface_options->option_length );
+				while ((zeroes > 0) && (result != -1)) {
+					result = write( handle->fd, "\0", 1 );
+					zeroes--;
+				}
+				interface_options = (const option_header *) &((uint8_t *)interface_options)[4+paddedsz];
+				handle->interface_description_size += (4+paddedsz);
+			}
+			handle->next_interface_option_offset = handle->interface_description_size;
+		}
+	}
+
+	if (retval == PCAPNG_OK) {
+		if (result == -1) {
+			retval = PCAPNG_FILE_WRITE_ERROR;
+		}
+		else {
+			/* determine the size of interface description with desired space */
+			zeroes = (size_t) PGSZ*((handle->interface_description_size + 4 +
+						 interface_options_space + PGSZ - 1)/PGSZ) -
+				handle->interface_description_size;
+			handle->interface_description_size += zeroes;
+			while ((zeroes > 0) && (result != -1)) {
+				result = write( handle->fd, "\0", 1 );
+				zeroes--;
+			}
+
+			/* mmap the interface description */
+			handle->interface_description = mmap( NULL, handle->interface_description_size, 
+							      PROT_READ|PROT_WRITE,
+							      MAP_SHARED,
+							      handle->fd,
+							      handle->section_header_size );
+		}
+	}
+
+	if (retval == PCAPNG_OK) {
+		if (result == -1) {
+			retval = PCAPNG_FILE_WRITE_ERROR;
+		}
+		else if (handle->interface_description == MAP_FAILED) {
+			retval = PCAPNG_MMAP_FAILED;
+		}
+		else {
+			uint8_t * dest = &((uint8_t *)handle->section_header)[handle->next_section_option_offset];
+			padopt.option_length = handle->section_header_size -
+				handle->next_section_option_offset - 12;
+
+			/* Add padding options, update the header sizes. */
+			(void) memcpy( dest, &padopt, sizeof( padopt ) );
+			handle->section_header->block_total_length =
+				(uint32_t) handle->section_header_size;
+			((uint32_t*)handle->section_header)[handle->section_header_size/4-1] =
+				(uint32_t) handle->section_header_size;
+
+			padopt.option_length = handle->interface_description_size -
+				handle->next_interface_option_offset - 12;
+			dest = &((uint8_t *)handle->interface_description)[handle->next_interface_option_offset];
+			(void) memcpy( dest, &padopt, sizeof( padopt ) );
+			handle->interface_description->block_total_length =
+				(uint32_t) handle->interface_description_size;
+			((uint32_t*)handle->interface_description)[handle->interface_description_size/4-1] =
+				(uint32_t) handle->interface_description_size;
+
+			handle->section_header->section_length = (uint64_t) handle->interface_description_size;
+		}
+	}
+
+	if (retval != PCAPNG_OK) {
+		(void) pcapng_close( handle );
+	}
+
+	return retval;
+}
+
+PCAPNG_RESULT pcapng_append_section_option( PCAPNG_HANDLE * handle,
+					    const option_header * section_option )
+{
+	PCAPNG_RESULT retval = PCAPNG_OK;
+	if (handle && (handle->fd != -1)) {
+		if (handle->section_header &&
+		    (handle->section_header != MAP_FAILED) &&
+		    handle->next_section_option_offset &&
+		    section_option) {
+			size_t copysz = 4+section_option->option_length;
+			uint8_t * dest = &((uint8_t *)handle->section_header)[handle->next_section_option_offset];
+			(void) memcpy( dest, section_option, copysz );
+			handle->next_section_option_offset += 4*((copysz+3)/4);
+
+			/* update padding option */
+			dest = &((uint8_t *)handle->section_header)[handle->next_section_option_offset];
+			padopt.option_length = handle->section_header_size -
+				handle->next_section_option_offset - 12;
+			(void) memcpy( dest, &padopt, sizeof( padopt ) );
+		}
+		else {
+			retval = PCAPNG_NO_MEMORY;
+		}
+	}
+	else {
+		retval = PCAPNG_INVALID_HANDLE;
+	}
+	return retval;
+}
+
+PCAPNG_RESULT pcapng_append_interface_option( PCAPNG_HANDLE * handle,
+					      const option_header * interface_option )
+{
+	PCAPNG_RESULT retval = PCAPNG_OK;
+	if (handle && (handle->fd != -1)) {
+		if (handle->interface_description &&
+		    (handle->interface_description != MAP_FAILED) &&
+		    handle->next_interface_option_offset &&
+		    interface_option) {
+			size_t copysz = 4+interface_option->option_length;
+			uint8_t * dest = &((uint8_t *)handle->interface_description)[handle->next_interface_option_offset];
+			(void) memcpy( dest, interface_option, copysz );
+			handle->next_interface_option_offset += 4*((copysz+3)/4);
+
+			/* update padding option */
+			dest = &((uint8_t *)handle->interface_description)[handle->next_interface_option_offset];
+			padopt.option_length = handle->interface_description_size -
+				handle->next_interface_option_offset - 12;
+			(void) memcpy( dest, &padopt, sizeof( padopt ) );
+		}
+		else {
+			retval = PCAPNG_NO_MEMORY;
+		}
+	}
+	else {
+		retval = PCAPNG_INVALID_HANDLE;
+	}
+	return retval;
+}
+
+PCAPNG_RESULT pcapng_append_packet( PCAPNG_HANDLE * handle,
+				    const enhanced_packet_block * packet )
+{
+	PCAPNG_RESULT retval = PCAPNG_OK;
+	if (handle && (handle->fd != -1)) {
+		size_t writesz = packet->block_total_length;
+		ssize_t result = write( handle->fd, packet, writesz );
+		if (result == -1) {
+			result = PCAPNG_FILE_WRITE_ERROR;
+		}
+		else {
+			handle->section_header->section_length += writesz;
+		}
+	}
+	else {
+		retval = PCAPNG_INVALID_HANDLE;
+	}
+	return retval;
+}
+
+PCAPNG_RESULT pcapng_close( PCAPNG_HANDLE * handle )
+{
+	if (handle->interface_description &&
+	    (handle->interface_description != MAP_FAILED)) {
+		(void) munmap( handle->interface_description,
+			       handle->interface_description_size );
+	}
+	if (handle->section_header &&
+	    (handle->section_header != MAP_FAILED)) {
+		(void) munmap( handle->section_header,
+			       handle->section_header_size );
+	}
+	if (handle->fd != -1) {
+		(void) close( handle->fd );
+	}
+	return PCAPNG_OK;
+}

--- a/lib/src/pcapng.h
+++ b/lib/src/pcapng.h
@@ -1,0 +1,198 @@
+/* -*- c -*- */
+/*
+ * Copyright 2014 Christopher D. Kilgour techie AT whiterocker.com
+ *
+ * This file is part of libbtbb
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with libbtbb; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef PCAPNG_DOT_H
+#define PCAPNG_DOT_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+typedef struct __attribute__((packed)) {
+	uint16_t option_code;
+	uint16_t option_length;
+	uint32_t option_value[0];
+} option_header;
+
+#define OPT_ENDOFOPT 0
+#define OPT_COMMENT  1
+
+typedef struct __attribute__((packed)) {
+	uint32_t block_type;
+	uint32_t block_total_length;
+	uint32_t byte_order_magic;
+	uint16_t major_version;
+	uint16_t minor_version;
+	uint64_t section_length;
+	option_header options[0];
+} section_header_block;
+
+#define SECTION_HEADER_BYTE_ORDER_MAGIC 0x1a2b3c4d
+
+#define SHB_HARDWARE 2
+#define SHB_OS       3
+#define SHB_USERAPPL 4
+
+typedef struct __attribute__((packed)) {
+	uint32_t block_type;
+	uint32_t block_total_length;
+	uint16_t link_type;
+	uint16_t reserved;
+	uint32_t snaplen;
+	option_header options[0];
+} interface_description_block;
+
+#define IF_NAME        2
+#define IF_DESCRIPTION 3
+#define IF_IPV4ADDR    4
+#define IF_IPV6ADDR    5
+#define IF_MACADDR     6
+#define IF_EUIADDR     7
+#define IF_SPEED       8
+#define IF_TSRESOL     9
+#define IF_TZONE       10
+#define IF_FILTER      11
+#define IF_OS          12
+#define IF_FCSLEN      13
+#define IF_TSOFFSET    14
+
+typedef struct __attribute__((packed)) {
+	uint32_t block_type;
+	uint32_t block_total_length;
+	uint32_t interface_id;
+	uint32_t timestamp_high;
+	uint32_t timestamp_low;
+	uint32_t captured_len;
+	uint32_t packet_len;
+	uint32_t packet_data[0];
+} enhanced_packet_block;
+
+#define EPB_FLAGS     2
+#define EPB_HASH      3
+#define EPB_DROPCOUNT 4
+
+typedef struct __attribute__((packed)) {
+	uint32_t block_type;
+	uint32_t block_total_length;
+	uint32_t packet_len;
+	uint32_t packet_data[0];
+} simple_packet_block;
+
+typedef struct __attribute__((packed)) {
+	uint32_t block_type;
+	uint32_t block_total_length;
+	uint16_t record_type;
+	uint16_t record_length;
+	uint32_t record_value[0];
+} name_resolution_block;
+
+#define NRES_ENDOFRECORD 0
+#define NRES_IP4RECORD   1
+#define NRES_IP6RECORD   2
+
+#define NS_DNSNAME    2
+#define NS_DNSIP4ADDR 3
+#define NS_DNSIP6ADDR 4
+
+typedef struct __attribute__((packed)) {
+	uint32_t block_type;
+	uint32_t block_total_length;
+	uint32_t interface_id;
+	uint32_t timestamp_high;
+	uint32_t timestamp_low;
+	option_header options[0];
+} interface_statistics_block;
+
+#define ISB_STARTTIME    2
+#define ISB_ENDTIME      3
+#define ISB_IFRECV       4
+#define ISB_IFDROP       5
+#define ISB_FILTERACCEPT 6
+#define ISB_OSDROP       7
+#define ISB_USRDELIV     8
+
+#define BLOCK_TYPE_INTERFACE            0x00000001
+#define BLOCK_TYPE_SIMPLE_PACKET        0x00000003
+#define BLOCK_TYPE_NAME_RESOLUTION      0x00000004
+#define BLOCK_TYPE_INTERFACE_STATISTICS 0x00000005
+#define BLOCK_TYPE_ENHANCED_PACKET      0x00000006
+#define BLOCK_TYPE_SECTION_HEADER       0x0a0d0d0a
+
+typedef struct {
+	int fd;
+	section_header_block * section_header;
+	size_t section_header_size;
+	size_t next_section_option_offset;
+	interface_description_block * interface_description;
+	size_t interface_description_size;
+	size_t next_interface_option_offset;
+} PCAPNG_HANDLE;
+
+typedef enum {
+	PCAPNG_OK = 0,
+	PCAPNG_INVALID_HANDLE,
+	PCAPNG_FILE_NOT_ALLOWED,
+	PCAPNG_FILE_EXISTS,
+	PCAPNG_TOO_MANY_FILES_OPEN,
+	PCAPNG_NO_MEMORY,
+	PCAPNG_FILE_WRITE_ERROR,
+	PCAPNG_MMAP_FAILED,
+} PCAPNG_RESULT;
+
+/**
+ * Create a new PCAP-NG file and set aside space in the section and
+ * interface headers for options to be recorded/added while packets
+ * are captured.
+ *
+ * @param handle                  pointer to a handle that is populated by this call
+ * @param filename                file to create
+ * @param section_options         list of initial section options, can be NULL
+ * @param section_options_space   size in bytes dedicated to storing extra section
+ *                                options; will be rounded up so section header
+ *                                is an integer number of memory pages
+ * @param link_type
+ * @param snaplen
+ * @param interface_options       list of initial interface options, can be NULL
+ * @param interface_options_space size in bytes dedicated to storing extra interface
+ *                                options; will be rounded up so interface header
+ *                                is an integer number of memory pages
+ * @returns                       0 on success, non zero result code otherwisex
+ */
+PCAPNG_RESULT pcapng_create( PCAPNG_HANDLE * handle,
+			     const char * filename,
+			     const option_header * section_options,
+			     const size_t section_options_space,
+			     const uint16_t link_type,
+			     const uint32_t snaplen,
+			     const option_header * interface_options,
+			     const size_t interface_options_space );
+
+PCAPNG_RESULT pcapng_append_section_option( PCAPNG_HANDLE * handle,
+					    const option_header * section_option );
+
+PCAPNG_RESULT pcapng_append_interface_option( PCAPNG_HANDLE * handle,
+					      const option_header * interface_option );
+
+PCAPNG_RESULT pcapng_append_packet( PCAPNG_HANDLE * handle,
+				    const enhanced_packet_block * packet );
+
+PCAPNG_RESULT pcapng_close( PCAPNG_HANDLE * handle );
+
+#endif /* PCAPNG_DOT_H */


### PR DESCRIPTION
LINKTYPE_BLUETOOTH_BREDR_BB and LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR.

Includes:
- Add support for BTLE access address validity determination.
- Refactor BTLE support with accessors and opaque internals similar
  to BR support.
