### PR TITLE
cmake: Fix libbtbb.pc.in.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -19,6 +19,8 @@
 # Boston, MA 02110-1301, USA.
 #
 
+include(GNUInstallDirs)
+
 # Based heavily upon the hackrf cmake setup.
 
 project(libbtbb C)

--- a/lib/libbtbb.pc.in
+++ b/lib/libbtbb.pc.in
@@ -1,7 +1,7 @@
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: Bluetooth Baseband Library
 Description: C Utility Library


### PR DESCRIPTION
The @prefix@, @exec_prefix@, @libdir@ and @includedir@ variables are not
set by cmake. Set the values in the libbtbb.pc.in file by including the
GNUInstallDirs.cmake file in CMakeLists.txt. This creates the
CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_INCLUDEDIR variables.

This change allows user to configure for installing into non-standard
locations as such:

    mkdir build
    cd build
    cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ..