### PR TITLE
Add AFH support to hopping sequence detection

### DIFF
--- a/lib/src/bluetooth_piconet.c
+++ b/lib/src/bluetooth_piconet.c
@@ -29,6 +29,15 @@
 int perm_table_initialized = 0;
 char perm_table[0x20][0x20][0x200];
 
+/* count the number of 1 bits in a uint64_t */
+int count_bits(uint8_t n)
+{
+	int i = 0;
+	for (i = 0; n != 0; i++)
+		n &= n - 1;
+	return i;
+}
+
 btbb_piconet *
 btbb_piconet_new(void)
 {
@@ -109,9 +118,13 @@ void btbb_piconet_set_clk_offset(btbb_piconet *pn, int clk_offset)
 
 void btbb_piconet_set_afh_map(btbb_piconet *pn, uint8_t *afh_map) {
 	int i;
+	pn->used_channels = 0;
 	// DGS: Unroll this?
-	for(i=0; i<10; i++)
+	for(i=0; i<10; i++) {
 		pn->afh_map[i] = afh_map[i];
+		pn->used_channels += count_bits(pn->afh_map[i]);
+	}
+	get_hop_pattern(pn);
 }
 
 uint8_t *btbb_piconet_get_afh_map(btbb_piconet *pn) {
@@ -120,17 +133,43 @@ uint8_t *btbb_piconet_get_afh_map(btbb_piconet *pn) {
 
 void btbb_piconet_set_channel_seen(btbb_piconet *pn, uint8_t channel)
 {
-	pn->afh_map[channel/8] |= 0x1 << (channel % 8);
+	if(!(pn->afh_map[channel/8] & 0x1 << (channel % 8))) {
+		pn->afh_map[channel/8] |= 0x1 << (channel % 8);
+		pn->used_channels++;
+		get_hop_pattern(pn);
+	}
+}
+
+uint8_t btbb_piconet_get_channel_seen(btbb_piconet *pn, uint8_t channel)
+{
+	if(channel < BT_NUM_CHANNELS && channel >= 0)
+		return ( pn->afh_map[channel/8] & (1 << (channel % 8)) ) != 0;
+	else
+		return 1;
 }
 
 /* do all the precalculation that can be done before knowing the address */
 void precalc(btbb_piconet *pn)
 {
-	int i;
+	int i = 0;
+	int j = 0;
+	int chan;
 
 	/* populate frequency register bank*/
-	for (i = 0; i < BT_NUM_CHANNELS; i++)
+	for (i = 0; i < BT_NUM_CHANNELS; i++) {
+
+		/* AFH is used, hopping sequence contains only used channels */
+		if(btbb_piconet_get_flag(pn, BTBB_IS_AFH)) {
+			chan = (i * 2) % BT_NUM_CHANNELS;
+			if(btbb_piconet_get_channel_seen(pn, chan))
+				pn->bank[j++] = chan;
+		} 
+
+		/* all channels are used */
+		else {
 			pn->bank[i] = ((i * 2) % BT_NUM_CHANNELS);
+		}
+	}
 	/* actual frequency is 2402 + pn->bank[i] MHz */
 
 }
@@ -252,44 +291,50 @@ int fast_perm(int z, int p_high, int p_low)
 /* generate the complete hopping sequence */
 static void gen_hops(btbb_piconet *pn)
 {
-	/* a, b, c, d, e, f, x, y1, y2 are variable names used in section 2.6 of the spec */
-	/* b is already defined */
-	/* e is already defined */
-	int a, c, d, f, x;
-	int h, i, j, k, c_flipped, perm_in, perm_out;
+	// /* a, b, c, d, e, f, x, y1, y2 are variable names used in section 2.6 of the spec */
+	// /* b is already defined */
+	// /* e is already defined */
+	// int a, c, d, f, x;
+	// int h, i, j, k, c_flipped, perm_in, perm_out;
 
-	/* sequence index = clock >> 1 */
-	/* (hops only happen at every other clock value) */
-	int index = 0;
-	f = 0;
+	// /* sequence index = clock >> 1 */
+	// /* (hops only happen at every other clock value) */
+	// int index = 0;
+	// f = 0;
 
-	/* nested loops for optimization (not recalculating every variable with every clock tick) */
-	for (h = 0; h < 0x04; h++) { /* clock bits 26-27 */
-		for (i = 0; i < 0x20; i++) { /* clock bits 21-25 */
-			a = pn->a1 ^ i;
-			for (j = 0; j < 0x20; j++) { /* clock bits 16-20 */
-				c = pn->c1 ^ j;
-				c_flipped = c ^ 0x1f;
-				for (k = 0; k < 0x200; k++) { /* clock bits 7-15 */
-					d = pn->d1 ^ k;
-					for (x = 0; x < 0x20; x++) { /* clock bits 2-6 */
-						perm_in = ((x + a) % 32) ^ pn->b;
-						/* y1 (clock bit 1) = 0, y2 = 0 */
-						perm_out = fast_perm(perm_in, c, d);
-						pn->sequence[index] = pn->bank[(perm_out + pn->e + f) % BT_NUM_CHANNELS];
-						if (btbb_piconet_get_flag(pn, BTBB_IS_AFH)) {
-							pn->sequence[index + 1] = pn->sequence[index];
-						} else {
-							/* y1 (clock bit 1) = 1, y2 = 32 */
-							perm_out = fast_perm(perm_in, c_flipped, d);
-							pn->sequence[index + 1] = pn->bank[(perm_out + pn->e + f + 32) % BT_NUM_CHANNELS];
-						}
-						index += 2;
-					}
-					f += 16;
-				}
-			}
-		}
+	// /* nested loops for optimization (not recalculating every variable with every clock tick) */
+	// for (h = 0; h < 0x04; h++) { /* clock bits 26-27 */
+	// 	for (i = 0; i < 0x20; i++) { /* clock bits 21-25 */
+	// 		a = pn->a1 ^ i;
+	// 		for (j = 0; j < 0x20; j++) { /* clock bits 16-20 */
+	// 			c = pn->c1 ^ j;
+	// 			c_flipped = c ^ 0x1f;
+	// 			for (k = 0; k < 0x200; k++) { /* clock bits 7-15 */
+	// 				d = pn->d1 ^ k;
+	// 				for (x = 0; x < 0x20; x++) { /* clock bits 2-6 */
+	// 					perm_in = ((x + a) % 32) ^ pn->b;
+	// 					/* y1 (clock bit 1) = 0, y2 = 0 */
+	// 					perm_out = fast_perm(perm_in, c, d);
+	// 					pn->sequence[index] = pn->bank[(perm_out + pn->e + f) % BT_NUM_CHANNELS];
+	// 					if (btbb_piconet_get_flag(pn, BTBB_IS_AFH)) {
+	// 						pn->sequence[index + 1] = pn->sequence[index];
+	// 					} else {
+	// 						/* y1 (clock bit 1) = 1, y2 = 32 */
+	// 						perm_out = fast_perm(perm_in, c_flipped, d);
+	// 						pn->sequence[index + 1] = pn->bank[(perm_out + pn->e + f + 32) % BT_NUM_CHANNELS];
+	// 					}
+	// 					index += 2;
+	// 				}
+	// 				f += 16;
+	// 			}
+	// 		}
+	// 	}
+	// }
+
+	int i; // FIXME implement optimization for AFH
+
+	for(i=0;i<SEQUENCE_LENGTH;i++) {
+		pn->sequence[i] = single_hop(i, pn);
 	}
 }
 
@@ -319,31 +364,32 @@ static hopping_struct *hopping_map = NULL;
 /* Function to fetch piconet hopping patterns */
 void get_hop_pattern(btbb_piconet *pn)
 {
-       hopping_struct *s;
-       uint64_t key;
-
-	   /* Two stages to avoid "left shift count >= width of type" warning */
-       key = btbb_piconet_get_flag(pn, BTBB_IS_AFH);
-       key = (key<<32) | (pn->UAP<<24) | pn->LAP;
-       HASH_FIND(hh, hopping_map, &key, 4, s);
-       
-       if (s == NULL) {
-               gen_hop_pattern(pn);
-               s = malloc(sizeof(hopping_struct));
-               s->key = key;
-               s->sequence = pn->sequence;
-               HASH_ADD(hh, hopping_map, key, 4, s);
-       } else {
-               printf("\nFound hopping sequence in cache.\n");
-               pn->sequence = s->sequence;
-       }
+	hopping_struct *s;
+	uint64_t key;
+ 
+	/* Two stages to avoid "left shift count >= width of type" warning */
+	key = btbb_piconet_get_flag(pn, BTBB_IS_AFH);
+	key = (key<<39) | ((uint64_t)pn->used_channels<<32) | (pn->UAP<<24) | pn->LAP;
+	HASH_FIND(hh, hopping_map, &key, 4, s);
+	
+	if (s == NULL) {
+		gen_hop_pattern(pn);
+		s = malloc(sizeof(hopping_struct));
+		s->key = key;
+		s->sequence = pn->sequence;
+		HASH_ADD(hh, hopping_map, key, 4, s);
+	} else {
+		printf("\nFound hopping sequence in cache.\n");
+		pn->sequence = s->sequence;
+	}
 }
 
 /* determine channel for a particular hop */
-/* replaced with gen_hops() for a complete sequence but could still come in handy */
+/* borrowed from ubertooth firmware to support AFH */
 char single_hop(int clock, btbb_piconet *pn)
 {
-	int a, c, d, f, x, y1, y2;
+	int a, c, d, x, y1, y2, perm, next_channel;
+	uint32_t base_f, f, f_dash;
 
 	/* following variable names used in section 2.6 of the spec */
 	x = (clock >> 2) & 0x1f;
@@ -354,10 +400,21 @@ char single_hop(int clock, btbb_piconet *pn)
 	c = (pn->c1 ^ (clock >> 16)) & 0x1f;
 	d = (pn->d1 ^ (clock >> 7)) & 0x1ff;
 	/* e is already defined */
-	f = (clock >> 3) & 0x1fffff0;
+	base_f = (clock >> 3) & 0x1fffff0;
+	f = base_f % BT_NUM_CHANNELS;
 
+	perm = fast_perm(
+		((x + a) % 32) ^ pn->b,
+		(y1 * 0x1f) ^ c,
+		d);
 	/* hop selection */
-	return(pn->bank[(fast_perm(((x + a) % 32) ^ pn->b, (y1 * 0x1f) ^ c, d) + pn->e + f + y2) % BT_NUM_CHANNELS]);
+	if(btbb_piconet_get_flag(pn, BTBB_IS_AFH)) {
+		f_dash = base_f % pn->used_channels;
+		next_channel = pn->bank[(perm + pn->e + f_dash + y2) % pn->used_channels];
+	} else {
+		next_channel = pn->bank[(perm + pn->e + f + y2) % BT_NUM_CHANNELS];
+	}
+	return next_channel;
 }
 
 /* look up channel for a particular hop */
@@ -368,7 +425,7 @@ char hop(int clock, btbb_piconet *pn)
 
 static char aliased_channel(char channel)
 {
-		return ((channel + 24) % ALIASED_CHANNELS) + 26;
+	return ((channel + 24) % ALIASED_CHANNELS) + 26;
 }
 
 /* create list of initial candidate clock values (hops with same channel as first observed hop) */
@@ -486,7 +543,7 @@ static void reset(btbb_piconet *pn)
 	 */
 	btbb_piconet_set_flag(pn, BTBB_IS_AFH,
 			      btbb_piconet_get_flag(pn, BTBB_LOOKS_LIKE_AFH));
-	btbb_piconet_set_flag(pn, BTBB_LOOKS_LIKE_AFH, 0);
+	// btbb_piconet_set_flag(pn, BTBB_LOOKS_LIKE_AFH, 0);
 	//int i;
 	//for(i=0; i<10; i++)
 	//	pn->afh_map[i] = 0;
@@ -579,7 +636,7 @@ int btbb_uap_from_header(btbb_packet *pkt, btbb_piconet *pn)
 		pn->first_pkt_time = clkn;
 
 	// Set afh channel map
-	pn->afh_map[pkt->channel/8] |= 0x1 << (pkt->channel % 8);
+	btbb_piconet_set_channel_seen(pn, pkt->channel);
 
 	if (pn->packets_observed < MAX_PATTERN_LENGTH) {
 		pn->pattern_indices[pn->packets_observed] = clkn - pn->first_pkt_time;
@@ -774,10 +831,15 @@ void btbb_print_afh_map(btbb_piconet *pn) {
 	uint8_t *afh_map;
 	afh_map = pn->afh_map;
 
-	/* Printed ch78 -> ch0 */
-	printf("\tAFH Map=0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n",
-		   afh_map[9], afh_map[8], afh_map[7], afh_map[6], afh_map[5],
-		   afh_map[4], afh_map[3], afh_map[2], afh_map[1], afh_map[0]);
+	/* Print like hcitool does */
+	printf("AFH map: 0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n",
+	       afh_map[0], afh_map[1], afh_map[2], afh_map[3], afh_map[4],
+	       afh_map[5], afh_map[6], afh_map[7], afh_map[8], afh_map[9]);
+
+	// /* Printed ch78 -> ch0 */
+	// printf("\tAFH Map=0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n",
+	//        afh_map[9], afh_map[8], afh_map[7], afh_map[6], afh_map[5],
+	//        afh_map[4], afh_map[3], afh_map[2], afh_map[1], afh_map[0]);
 }
 
 /* Container for survey piconets */
@@ -832,6 +894,7 @@ btbb_piconet *btbb_next_survey_result() {
 }
 
 int btbb_process_packet(btbb_packet *pkt, btbb_piconet *pn) {
+	btbb_piconet_set_channel_seen(pn, pkt->channel);
 	if (survey_mode) {
 		pn = get_piconet(btbb_packet_get_lap(pkt));
 		btbb_piconet_set_channel_seen(pn, pkt->channel);

--- a/lib/src/bluetooth_piconet.h
+++ b/lib/src/bluetooth_piconet.h
@@ -41,6 +41,9 @@ struct btbb_piconet {
 	/* AFH channel map - either read or derived from observed packets */
 	uint8_t afh_map[10];
 
+	/* Number of used channel derived from AFH channel map */
+	uint8_t used_channels;
+
 	/* lower address part (of master's BD_ADDR) */
 	uint32_t LAP;
 
@@ -122,5 +125,7 @@ char single_hop(int clock, btbb_piconet *pnet);
 char hop(int clock, btbb_piconet *pnet);
 
 void try_hop(btbb_packet *pkt, btbb_piconet *pn);
+
+void get_hop_pattern(btbb_piconet *pn);
 
 #endif /* INCLUDED_BLUETOOTH_PICONET_H */


### PR DESCRIPTION
`gen_hops()` now respects the channel map if the piconet uses AFH. This results in a faster and better detection of the hopping sequence when the channel map is known.

I'm also planning to write a host tool for Ubertooth to detect and track the channel map of a piconet.

Please let me know if my patch needs modifications. I will be happy to adopt them.