### PR TITLE
Increase LE_MAX_PAYLOAD size from 48 to 73

### DIFF
--- a/lib/src/pcap-common.h
+++ b/lib/src/pcap-common.h
@@ -124,6 +124,6 @@ typedef struct __attribute__((packed)) _pcap_bluetooth_le_ll_header {
 #define LE_MIC_CHECKED       0x1000
 #define LE_MIC_VALID         0x2000
 
-#define LE_MAX_PAYLOAD       48
+#define LE_MAX_PAYLOAD       73
 
 #endif /* PCAP_COMMON_DOT_H */


### PR DESCRIPTION
`ubertooth-btle -p -c test.pcap` would crash when turning iOS device BT
off then on when le_packet was 48 wide