### PR TITLE
pcap-common: increase LE_MAX_PAYLOAD

### DIFF
--- a/lib/src/pcap-common.h
+++ b/lib/src/pcap-common.h
@@ -124,6 +124,6 @@ typedef struct __attribute__((packed)) _pcap_bluetooth_le_ll_header {
 #define LE_MIC_CHECKED       0x1000
 #define LE_MIC_VALID         0x2000
 
-#define LE_MAX_PAYLOAD       48
+#define LE_MAX_PAYLOAD       265
 
 #endif /* PCAP_COMMON_DOT_H */


### PR DESCRIPTION
Running `ubertooth-btle -p -c /tmp/cap` (built from 2015-09-R2) while monitoring a TI SensorTag produced:

    *** stack smashing detected ***: /opt/Ubertooth/ubertooth/host/build/ubertooth-tools/src/ubertooth-btle terminated

    (gdb) where
    #0  0x00007ffff75a9cc9 in __GI_raise (sig=sig@entry=6)
        at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
    #1  0x00007ffff75ad0d8 in __GI_abort () at abort.c:89
    #2  0x00007ffff75e6394 in __libc_message (do_abort=do_abort@entry=1, 
        fmt=fmt@entry=0x7ffff76f252b "*** %s ***: %s terminated\n")
        at ../sysdeps/posix/libc_fatal.c:175
    #3  0x00007ffff767dc9c in __GI___fortify_fail (msg=<optimized out>, 
        msg@entry=0x7ffff76f2513 "stack smashing detected") at fortify_fail.c:37
    #4  0x00007ffff767dc40 in __stack_chk_fail () at stack_chk_fail.c:28
    #5  0x00007ffff7945948 in lell_pcap_append_ppi_packet (h=0x604010, 
        ns=1441477789853184850, clkn_high=9 '\t', rssi_min=-35 '\335', 
        rssi_max=-25 '\347', rssi_avg=-31 '\341', rssi_count=17 '\021', 
        pkt=0x60a0e0) at /opt/Ubertooth/libbtbb/lib/src/pcap.c:404
    #6  0x00007ffff7bd2a9c in cb_btle ()
       from /opt/Ubertooth/ubertooth/host/build/libubertooth/src/libubertooth.so.0
    #7  0x0000000000401ac8 in main ()
    (gdb) fr 5
    #5  0x00007ffff7945948 in lell_pcap_append_ppi_packet (h=0x604010, 
        ns=1441477789853184850, clkn_high=9 '\t', rssi_min=-35 '\335', 
        rssi_max=-25 '\347', rssi_avg=-31 '\341', rssi_count=17 '\021', 
        pkt=0x60a0e0) at /opt/Ubertooth/libbtbb/lib/src/pcap.c:404
    404	}
    (gdb) p *pkt
    $4 = {
      symbols = "8~k9\017\277q\270@\267;\000\211\375\220\376f\303\002;w\254b\035\240t\367\000\022U\367c\200\274>Lτ\277:\025\272\\\350*\\1\336^\336\340\034@\000\000\000\000\000\000\027\354;f\222", access_address = 963345976, 
      channel_idx = 37 '%', channel_k = 0 '\000', length = 63, 
      clk100ns = 3053417836, adv_type = 15 '\017', adv_tx_add = 0, adv_rx_add = 0, 
      access_address_offenses = 32, refcount = 1, flags = {as_bits = {
          access_address_ok = 0}, as_word = 0}}
    (gdb) 

which probably corresponds to line 398:

    (void) memcpy( &pcap_pkt.le_packet[0], &pkt->symbols[0], pkt->length + 9 ); // FIXME where does the 9 come from?

since `pkt->length+9` = 72 bytes are copied into a 48-byte buffer.

This is a true patch that just increases the buffer to what may be the correct maximum.  In practice pcap.c should be checking the size before it invokes memcpy, but I don't know how you'd want the error communicated back to the caller so didn't try that.

