### PR TITLE
support passive detection of the AFH channel map

### DIFF
--- a/lib/src/btbb.h
+++ b/lib/src/btbb.h
@@ -180,7 +180,9 @@ void btbb_piconet_set_clk_offset(btbb_piconet *pn, int clk_offset);
 void btbb_piconet_set_flag(btbb_piconet *pn, int flag, int val);
 int btbb_piconet_get_flag(const btbb_piconet *pn, int flag);
 
-void btbb_piconet_set_channel_seen(btbb_piconet *pn, uint8_t channel);
+uint8_t btbb_piconet_set_channel_seen(btbb_piconet *pn, uint8_t channel);
+uint8_t btbb_piconet_clear_channel_seen(btbb_piconet *pn, uint8_t channel);
+uint8_t btbb_piconet_get_channel_seen(btbb_piconet *pn, uint8_t channel);
 void btbb_piconet_set_afh_map(btbb_piconet *pn, uint8_t *afh_map);
 uint8_t *btbb_piconet_get_afh_map(btbb_piconet *pn);
 


### PR DESCRIPTION
* add method clear_channel_seen() to tell the piconet that a channel is not used (any more)
* enhance the calculation of the hopping pattern to support AFH hopping patterns

These changes are part of an Ubertooth host tool for AFH channel map detection. This was the topic of my diploma thesis and I will commit it as soon as I have refactored it.