### PR TITLE
Started logging the payloads to the output files

### DIFF
--- a/lib/src/pcap-common.h
+++ b/lib/src/pcap-common.h
@@ -61,23 +61,6 @@ inline uint64_t le64toh(uint64_t little_endian_64bits) { return little_endian_64
 
 /* --------------------------------- BR/EDR ----------------------------- */
 
-#if !defined( DLT_BLUETOOTH_BREDR_BB )
-#define DLT_BLUETOOTH_BREDR_BB 255
-#endif
-typedef struct __attribute__((packed)) _pcap_bluetooth_bredr_bb_header {
-        uint8_t rf_channel;
-        int8_t signal_power;
-        int8_t noise_power;
-        uint8_t access_code_offenses;
-        uint8_t payload_transport_rate;
-        uint8_t corrected_header_bits;
-        int16_t corrected_payload_bits;
-        uint32_t lap;
-        uint32_t ref_lap_uap;
-        uint32_t bt_header;
-        uint16_t flags;
-        uint8_t  br_edr_payload[0];
-} pcap_bluetooth_bredr_bb_header;
 
 #define BREDR_DEWHITENED        0x0001
 #define BREDR_SIGPOWER_VALID    0x0002
@@ -95,6 +78,24 @@ typedef struct __attribute__((packed)) _pcap_bluetooth_bredr_bb_header {
 #define BREDR_MIC_VALID         0x2000
 
 #define BREDR_MAX_PAYLOAD       400
+#if !defined( DLT_BLUETOOTH_BREDR_BB )
+#define DLT_BLUETOOTH_BREDR_BB 255
+#endif
+
+typedef struct __attribute__((packed)) _pcap_bluetooth_bredr_bb_header {
+        uint8_t rf_channel;
+        int8_t signal_power;
+        int8_t noise_power;
+        uint8_t access_code_offenses;
+        uint8_t payload_transport_rate;
+        uint8_t corrected_header_bits;
+        int16_t corrected_payload_bits;
+        uint32_t lap;
+        uint32_t ref_lap_uap;
+        uint32_t bt_header;
+        uint16_t flags;
+	uint8_t bredr_payload[BREDR_MAX_PAYLOAD];
+} pcap_bluetooth_bredr_bb_header;
 
 /* --------------------------------- Low Energy ---------------------------- */
 

--- a/lib/src/pcap.c
+++ b/lib/src/pcap.c
@@ -108,7 +108,6 @@ typedef struct __attribute__((packed)) pcaprec_hdr_s {
 typedef struct {
 	pcaprec_hdr_t pcap_header;
 	pcap_bluetooth_bredr_bb_header bredr_bb_header;
-	uint8_t bredr_payload[BREDR_MAX_PAYLOAD];
 } pcap_bredr_packet;
 
 void btbb_pcap_dump(FILE *file, pcaprec_hdr_t *pcap_header, u_char *data) {
@@ -151,15 +150,15 @@ assemble_pcapng_bredr_packet( pcap_bredr_packet * pkt,
 	pkt->bredr_bb_header.access_code_offenses = access_code_offenses;
 	pkt->bredr_bb_header.payload_transport_rate =
 		(payload_transport << 4) | payload_rate;
-	pkt->bredr_bb_header.corrected_header_bits = corrected_header_bits;
+	pkt->bredr_bb_header.corrected_header_bits = corrected_header_bits; 
 	pkt->bredr_bb_header.corrected_payload_bits = htole16( corrected_payload_bits );
 	pkt->bredr_bb_header.lap = htole32( lap );
 	pkt->bredr_bb_header.ref_lap_uap = htole32( reflapuap );
-	pkt->bredr_bb_header.bt_header = htole16( bt_header );
+	pkt->bredr_bb_header.bt_header = htole32( bt_header ); 
 	pkt->bredr_bb_header.flags = htole16( flags );
 	if (caplen) {
-		assert(caplen <= sizeof(pkt->bredr_payload)); // caller ensures this, but to be safe..
-		(void) memcpy( &pkt->bredr_payload[0], payload, caplen );
+		assert(caplen <= sizeof(pkt->bredr_bb_header.bredr_payload)); // caller ensures this, but to be safe..
+		(void) memcpy( &pkt->bredr_bb_header.bredr_payload[0], payload, caplen );
 	}
 	else {
 		pkt->bredr_bb_header.flags &= htole16( ~BREDR_PAYLOAD_PRESENT );


### PR DESCRIPTION
This commit brings the BREDR headers up to the standard spec. The code should now copy data over into the correct payload. 