### PR TITLE
Fix the packet output so wireshark doesn't complain

### DIFF
--- a/lib/src/btbb.h
+++ b/lib/src/btbb.h
@@ -42,10 +42,9 @@
 #define BTBB_FOLLOWING         14
 
 /* Payload modulation */
-#define BTBB_MOD_UNKNOWN           0x00
-#define BTBB_MOD_GFSK              0x01
-#define BTBB_MOD_PI_OVER_2_DQPSK   0x02
-#define BTBB_MOD_8DPSK             0x03
+#define BTBB_MOD_GFSK              0x00
+#define BTBB_MOD_PI_OVER_2_DQPSK   0x01
+#define BTBB_MOD_8DPSK             0x02
 
 /* Transport types */
 #define BTBB_TRANSPORT_ANY     0x00

--- a/lib/src/pcap.c
+++ b/lib/src/pcap.c
@@ -136,7 +136,9 @@ assemble_pcapng_bredr_packet( pcap_bredr_packet * pkt,
 			      const uint16_t flags,
 			      const uint8_t * payload )
 {
-	uint32_t pcap_caplen = sizeof(pcap_bluetooth_bredr_bb_header)+caplen;
+	uint32_t pcap_caplen = sizeof(pcap_bluetooth_bredr_bb_header) -
+				sizeof(pkt->bredr_bb_header.bredr_payload) 
+				+ caplen;
 	uint32_t reflapuap = (ref_lap&0xffffff) | (ref_uap<<24);
 
 	pkt->pcap_header.ts_sec  = ns / 1000000000ull;

--- a/lib/src/pcap.c
+++ b/lib/src/pcap.c
@@ -161,6 +161,7 @@ assemble_pcapng_bredr_packet( pcap_bredr_packet * pkt,
 	if (caplen) {
 		assert(caplen <= sizeof(pkt->bredr_bb_header.bredr_payload)); // caller ensures this, but to be safe..
 		(void) memcpy( &pkt->bredr_bb_header.bredr_payload[0], payload, caplen );
+		pkt->bredr_bb_header.flags &= htole16( BREDR_PAYLOAD_PRESENT );
 	}
 	else {
 		pkt->bredr_bb_header.flags &= htole16( ~BREDR_PAYLOAD_PRESENT );

--- a/lib/src/pcap.c
+++ b/lib/src/pcap.c
@@ -161,7 +161,7 @@ assemble_pcapng_bredr_packet( pcap_bredr_packet * pkt,
 	if (caplen) {
 		assert(caplen <= sizeof(pkt->bredr_bb_header.bredr_payload)); // caller ensures this, but to be safe..
 		(void) memcpy( &pkt->bredr_bb_header.bredr_payload[0], payload, caplen );
-		pkt->bredr_bb_header.flags &= htole16( BREDR_PAYLOAD_PRESENT );
+		pkt->bredr_bb_header.flags |= htole16( BREDR_PAYLOAD_PRESENT );
 	}
 	else {
 		pkt->bredr_bb_header.flags &= htole16( ~BREDR_PAYLOAD_PRESENT );


### PR DESCRIPTION
A collection of minor fixes to the way to write out the BREDR packets to finish brining libbtbb in-line with the spec. 