### PR TITLE
Fix pcap magic number for nanoseconds

### DIFF
--- a/lib/src/pcap.c
+++ b/lib/src/pcap.c
@@ -47,7 +47,7 @@ typedef struct __attribute__((packed)) pcap_hdr_s {
 
 FILE *btbb_pcap_open(const char *filename, uint32_t dlt, uint32_t snaplen) {
 	pcap_hdr_t pcap_header = {
-		.magic_number = 0xa1b2c3d4,
+		.magic_number = 0xa1b23c4d,
 		.version_major = 2,
 		.version_minor = 4,
 		.thiszone = 0,


### PR DESCRIPTION
https://wiki.wireshark.org/Development/LibpcapFileFormat#Global_Header

"For nanosecond-resolution files, the writing application writes 0xa1b23c4d, with the two nibbles of the two lower-order bytes swapped, and the reading application will read either 0xa1b23c4d (identical) or 0x4d3cb2a1 (swapped)."
