### PR TITLE
Use `DLT_BLUETOOTH_LE_LL` for PPI rather than `DLT_USER0`.

### DIFF
--- a/lib/src/pcap-common.h
+++ b/lib/src/pcap-common.h
@@ -25,7 +25,6 @@
 // since we no longer rely on or assume the existence of libpcap,
 // hardcode these DLTs
 #define DLT_PPI 192
-#define DLT_USER0 147
 
 #if defined( __APPLE__ )
 #include <CoreServices/CoreServices.h>
@@ -98,6 +97,10 @@ typedef struct __attribute__((packed)) _pcap_bluetooth_bredr_bb_header {
 } pcap_bluetooth_bredr_bb_header;
 
 /* --------------------------------- Low Energy ---------------------------- */
+
+#if !defined( DLT_BLUETOOTH_LE_LL )
+#define DLT_BLUETOOTH_LE_LL 251
+#endif
 
 #if !defined( DLT_BLUETOOTH_LE_LL_WITH_PHDR )
 #define DLT_BLUETOOTH_LE_LL_WITH_PHDR 256

--- a/lib/src/pcap.c
+++ b/lib/src/pcap.c
@@ -396,7 +396,7 @@ lell_pcap_append_ppi_packet(lell_pcap_handle * h, const uint64_t ns,
 		pcap_pkt.ppi_packet_header.pph_version = 0;
 		pcap_pkt.ppi_packet_header.pph_flags = 0;
 		pcap_pkt.ppi_packet_header.pph_len = htole16(pcap_headerlen);
-		pcap_pkt.ppi_packet_header.pph_dlt = htole32(DLT_USER0);
+		pcap_pkt.ppi_packet_header.pph_dlt = htole32(DLT_BLUETOOTH_LE_LL);
 
 		pcap_pkt.ppi_fieldheader.pfh_type = htole16(PPI_BTLE);
 		pcap_pkt.ppi_fieldheader.pfh_datalen = htole16(sizeof(ppi_btle_t));


### PR DESCRIPTION
`DLT_USER*` is intended for private use.  It requires extra configuration in tools like Wireshark to make it actually work, and causes problems for Ubertooth users in other tools (eg: secdev/scapy#1673)

I don't have the hardware for this, so I cannot test this change.

Companion `ubertooth` PR: https://github.com/greatscottgadgets/ubertooth/pull/359