### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -32,6 +32,9 @@ set(c_sources ${CMAKE_CURRENT_SOURCE_DIR}/bluetooth_packet.c
               ${CMAKE_CURRENT_SOURCE_DIR}/pcapng-bt.c
 			  CACHE INTERNAL "List of C sources")
 set(c_headers ${CMAKE_CURRENT_SOURCE_DIR}/btbb.h
+              ${CMAKE_CURRENT_SOURCE_DIR}/bluetooth_piconet.h
+              ${CMAKE_CURRENT_SOURCE_DIR}/bluetooth_packet.h
+              ${CMAKE_CURRENT_SOURCE_DIR}/bluetooth_le_packet.h
 			  CACHE INTERNAL "List of C headers")
 
 if( NOT ${BUILD_SHARED_LIB} AND NOT ${BUILD_STATIC} )


### PR DESCRIPTION
added a list of installation files that are needed to access btbb_packet / lell_packet / piconet fields outside of libtbb sources