### PR TITLE
Fix 'u_char' undeclared on musl libc

### DIFF
--- a/lib/src/pcap.c
+++ b/lib/src/pcap.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <sys/types.h>
 
 typedef enum {
 	PCAP_OK = 0,


### PR DESCRIPTION
On musl libc we get build errors with 'u_char' undeclared and

```
 expected expression before ')' token
  205 |        btbb_pcap_dump(h->pcap_file, &pcap_pkt.pcap_header, (u_char *)&pcap_pkt.bredr_bb_header);
```

This PR fixes both the issues, one of the issues is caused by another.

Signed-off-by: brahmajit das <listout@protonmail.com>