### PR TITLE
packaging: update Macports portfile

### DIFF
--- a/packaging/Portfile
+++ b/packaging/Portfile
@@ -1,34 +1,46 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id$
 
 PortSystem          1.0
-PortGroup           cmake 1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        greatscottgadgets libbtbb 2014-02-R2
-categories          net security
-platforms           darwin
-maintainers         gmail.com:dominicgs
-license             GPL-2+
+name                libbtbb
+categories          devel net security
+description         Bluetooth baseband decoding library.
+long_description    Bluetooth baseband decoding library, forked from the GR-Bluetooth project. \
+                    It can be used to extract Bluetooth packet and piconet information \
+                    from Ubertooth devices as well as GR-Bluetooth/USRP.
+license             GPL-2
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 
-description         Bluetooth Baseband Decoding Library
+subport             ${name}-devel {}
 
-long_description \
-    LibBTBB is a Bluetooth Baseband processing library that supports Basic \
-    Rate and Bluetooth Smart (BLE) packets. It is used by the Ubertooth and \
-    gr-bluetooth packet sniffer implementations.
+if {${subport} eq "${name}"} {
+    conflicts       ${name}-devel
 
-homepage            https://github.com/greatscottgadgets/libbtbb
+    github.setup    greatscottgadgets libbtbb 2020-12-R1
+    checksums       rmd160  eca69c16710e4bf793cccfc722101e015a95b0e9 \
+                    sha256  aa0588f21701156ccbd6b388fafe63225b41dd5b37b390f6c0ed3504d259847a \
+                    size    308473
 
-checksums           rmd160  0adc5d59e611509cdcf8959be8b6e31704529e48 \
-                    sha256  04a187b6f17836437e5f9deecb0b643c75ec0eafce671e373d1d4c13fc104984
+} elseif {${subport} eq "${name}-devel"} {
+    conflicts       ${name}
 
-configure.dir       ${workpath}/build
-build.dir           ${configure.dir}
-
-post-extract {
-    file mkdir ${configure.dir}
+    github.setup    greatscottgadgets libbtbb f0fe1768b080b1333a5357e8308d900e1273ec7f
+    version         2022-08-26
+    checksums       rmd160  82d6f97e4070ec7f14b64d3d21063c3b4d82fd9f \
+                    sha256  daa64b8a746f87fb6a6f6e6c589ee251f98454d9b0093b665f883446b49d047f \
+                    size    310865
 }
 
-configure.post_args ../${name}-${version}
-configure.args-append -DPACKAGE_MANAGER=1
+set python_ver      310
+depends_build-append \
+                    port:python${python_ver}
+
+# cc1: error: unrecognized command line option "-std=gnu90"
+compiler.blacklist-append *gcc-4.*
+
+platform darwin powerpc {
+    # Needed for Rosetta
+    compiler.blacklist-append clang
+}


### PR DESCRIPTION
Updates Macports packaging.

I am not sure if the current portfile dated back to 2014 was in Macports before, but I have restored `libbtbb` into Macports now.
https://github.com/macports/macports-ports/pull/16538

Build is confirmed on macOS 12, macOS 11 (CI checks in the PR), 10.8.5, 10.6.8 Rosetta and 10.6 PPC.

P. S. There is no activity from @dominicgs  for past 3 years, but I will be happy to add him as a co-maintainer, if he happens to be interested.