### PR TITLE
Set CRC and payload decrypted flags PCAP packet header

### DIFF
--- a/lib/src/pcap.c
+++ b/lib/src/pcap.c
@@ -176,7 +176,7 @@ btbb_pcap_append_packet(btbb_pcap_handle * h, const uint64_t ns,
 			const btbb_packet *pkt)
 {
 	if (h && h->pcap_file) {
-		uint16_t flags = BREDR_DEWHITENED | BREDR_SIGPOWER_VALID |
+		uint16_t flags = BREDR_DEWHITENED | BREDR_SIGPOWER_VALID | BREDR_CRC_CHECKED | BREDR_CRC_VALID | BREDR_PAYLOAD_DECRYPTED |
 			((noisedbm < sigdbm) ? BREDR_NOISEPOWER_VALID : 0) |
 			((reflap != LAP_ANY) ? BREDR_REFLAP_VALID : 0) |
 			((refuap != UAP_ANY) ? BREDR_REFUAP_VALID : 0);


### PR DESCRIPTION
After attempting to sniff some Bluetooth BR/EDR traffic, I saw that the correct plaintext data was present in the packet bytes in Wireshark, but Wireshark was not decoding the packet any more than the "BT BR/EDR RF" packet type, even though I should have seen LMP and L2CAP packets decoded as well. Digging into the code for the Wireshark BT BR/EDR packet dissector shows that the LLID of the packets is only decoded if there is a non-zero data length, the CRC is checked, and the CRC is valid: https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-btbredr_rf.c#L1558-L1559

These bits should be set in the BT BR/EDR packet "Flags" field whenever `libbtbb` adds a new packet to the PCAP, but currently they're not being set.

This PR sets the `BREDR_CRC_CHECKED`, `BREDR_CRC_VALID`, and `BREDR_PAYLOAD_DECRYPTED` flags here so that the PCAP is properly decoded in Wireshark.

This solution probably can't be merged in its current state, as we're setting these flags without actually ensuring the data is encrypted or the CRC is valid. But hardcoding them was helpful for my use case, so I'm putting this PR up as an FYI of this issue and so others can use.

For a full solution, maybe `ubertooth-rx` and `ubertooth-follow` could have a command line flag that would set these flags when enabled?